### PR TITLE
gen: only send state-changes if the change occur.

### DIFF
--- a/lib/orogen/templates/tasks/TaskBase.cpp
+++ b/lib/orogen/templates/tasks/TaskBase.cpp
@@ -77,27 +77,42 @@ void <%= task.basename %>Base::setupComponentInterface()
         compact.join("\n") %>
 
 <% if task.extended_state_support? %>
-void <%= task.basename %>Base::report(States state)
+void <%= task.basename %>Base::report(States state, bool onlyIfChanged)
 {
-    _state.write(state);
+    if(this->state() != state || !onlyIfChanged)
+    {
+        _state.write(state);
+    }
 }
-void <%= task.basename %>Base::state(States state)
+void <%= task.basename %>Base::state(States state, bool onlyIfChanged)
 {
-    _state.write(state);
+    if(this->state() != state || !onlyIfChanged)
+    {
+        _state.write(state);
+    }
 }
-void <%= task.basename %>Base::error(States state)
+void <%= task.basename %>Base::error(States state, bool onlyIfChanged)
 {
-    _state.write(state);
+    if(this->state() != state || !onlyIfChanged)
+    {
+        _state.write(state);
+    }
     TaskContext::error();
 }
-void <%= task.basename %>Base::exception(States state)
+void <%= task.basename %>Base::exception(States state, bool onlyIfChanged)
 {
-    _state.write(state);
+    if(this->state() != state || !onlyIfChanged)
+    {
+        _state.write(state);
+    }
     TaskContext::exception();
 }
-void <%= task.basename %>Base::fatal(States state)
+void <%= task.basename %>Base::fatal(States state, bool onlyIfChanged)
 {
-    _state.write(state);
+    if(this->state() != state || !onlyIfChanged)
+    {
+        _state.write(state);
+    }
     TaskContext::fatal();
 }
 <%= task.basename %>Base::States <%= task.basename %>Base::state() const

--- a/lib/orogen/templates/tasks/TaskBase.hpp
+++ b/lib/orogen/templates/tasks/TaskBase.hpp
@@ -92,11 +92,11 @@ namespace <%= component.name %> {
         <% end %>
 
         <% if task.extended_state_support? %>
-        void report(States state);
-        void state(States state);
-        void error(States state);
-        void fatal(States state);
-        void exception(States state);
+        void report(States state, bool onlyIfChanged = true);
+        void state(States state, bool onlyIfChanged = true);
+        void error(States state, bool onlyIfChanged = true);
+        void fatal(States state, bool onlyIfChanged = true);
+        void exception(States state, bool onlyIfChanged = true);
         States state() const;
         <% end %>
 


### PR DESCRIPTION
This prevents a flood of messages in the logs (and syskit).
I recognized oftten that user simply call the state(FOO) function
independently if a change is needed.
This commit will only send the events if the new state is different than
the old one.
