### PR TITLE
loaders: register loaded models on self even if self is not root

### DIFF
--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -237,9 +237,6 @@ module OroGen
             # new typekit as argument
             def register_typekit_model(typekit)
                 loaded_typekits[typekit.name] = typekit
-                if root_loader != self
-                    return root_loader.register_typekit_model(typekit)
-                end
 
                 registry.merge typekit.registry
                 @interface_typelist |= typekit.interface_typelist
@@ -249,6 +246,10 @@ module OroGen
                 end
                 typekit_load_callbacks.each do |callback|
                     callback.call(typekit)
+                end
+
+                if root_loader != self
+                    root_loader.register_typekit_model(typekit)
                 end
             end
 
@@ -387,14 +388,15 @@ module OroGen
             # Registers this project's subobjects
             def register_project_model(project)
                 loaded_projects[project.name] = project
-                if root_loader != self
-                    return root_loader.register_project_model(project)
-                end
 
                 loaded_task_models.merge! project.tasks
                 loaded_deployment_models.merge! project.deployers
                 project_load_callbacks.each do |callback|
                     callback.call(project)
+                end
+
+                if root_loader != self
+                    root_loader.register_project_model(project)
                 end
             end
 


### PR DESCRIPTION
The current code was not registering new projects on self if self was
not the root loader. It makes no sense, we want to forward to the root
loader _and_ register locally so that one can "listen" to a particular
loader object regardless of its place in the hierarchy
