### PR TITLE
fix m-type generation for m-types that have the same basename

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -1758,7 +1758,7 @@ module Orocos
                     marshalling_code = Generation.
                         render_template 'typekit', 'marshalling_types.hpp', binding
 
-                    path = Generation.save_automatic 'typekit', 'types', self.name, "m_types", "#{type.method_name(false)}.hpp", marshalling_code
+                    path = Generation.save_automatic 'typekit', 'types', self.name, "m_types", "#{type.method_name(true)}.hpp", marshalling_code
                     self.load(path, true, options)
                 end
                 true


### PR DESCRIPTION
orogen was so far using the type basename as header filename, which meant
that two types with the same name (but different namespaces) would have
the same m-type filename, for instance:

  base::Wrench
  base::samples::Wrench

would have a m-type generated as base/m_types/Wrench.hpp

This commit switches to the full method name (including namespaces).
