### PR TITLE
Renamed reported typekit names from "/orogen/<foo>" to "<foo>".

### DIFF
--- a/lib/orogen/templates/typekit/Plugin.cpp
+++ b/lib/orogen/templates/typekit/Plugin.cpp
@@ -44,7 +44,7 @@ bool orogen_typekits::<%= typekit.name %>TypekitPlugin::loadOperators()
 bool orogen_typekits::<%= typekit.name %>TypekitPlugin::loadConstructors()
 { return true; }
 std::string orogen_typekits::<%= typekit.name %>TypekitPlugin::getName()
-{ return "/orogen/<%= typekit.name %>"; }
+{ return "<%= typekit.name %>"; }
 
 ORO_TYPEKIT_PLUGIN(orogen_typekits::<%= typekit.name %>TypekitPlugin);
 


### PR DESCRIPTION
This commit synchronizes the reported typekit names
in RTT with the typekits names written down in the
pkgconfig files for the deployments.