### PR TITLE
Fix setting of test suite in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ begin
             end
         end
     end
-    hoe_spec.test_globs = ['test/suite.rb']
+    config.test_globs = ['test/suite.rb']
 
     task :doc => :yard
 rescue LoadError


### PR DESCRIPTION
Fixes the following warning when running rake: 
WARN: cannot load the Hoe gem, or Hoe fails. Publishing tasks are disabled
WARN: error message is: undefined local variable or method `hoe_spec' for main:Object
