### PR TITLE
Add base_body to Operation

### DIFF
--- a/lib/orogen/spec/operation.rb
+++ b/lib/orogen/spec/operation.rb
@@ -36,6 +36,8 @@ module OroGen
 	    attr_reader :task
 	    # The operation name
 	    attr_reader :name
+	    # Implementation of the operation
+	    attr_accessor :base_body
             # True if this operation runs its associated C++ method in caller
             # thread (default is false)
             #


### PR DESCRIPTION
While the base_body is available in the ConfigurationObjectGeneration
during the code generation of operations, it is not available to the
Operation itself. If a hidden_operation is generated, this leads to a
missing base_body method when the TaskContext is used within a ruby script.