### PR TITLE
main deployment: initialize SIGINT handler differently.

### DIFF
--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -70,6 +70,8 @@ bool exiting;
 QApplication *qapp;
 <% end %>
 
+#include <string.h>
+
 namespace orogen
 {
 <% task_activities.each do |task| %>
@@ -402,10 +404,9 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
     }
 
     struct sigaction sigint_handler;
+    memset(&sigint_handler, 0, sizeof(sigint_handler));
     sigint_handler.sa_handler = &sigint_quit_orb;
     sigemptyset(&sigint_handler.sa_mask);
-    sigint_handler.sa_flags     = 0;
-    sigint_handler.sa_restorer  = 0;
     if (-1 == sigaction(SIGINT, &sigint_handler, 0))
     {
         std::cerr << "failed to install SIGINT handler" << std::endl;


### PR DESCRIPTION
This fixed issue https://github.com/orocos-toolchain/orogen/issues/47
The macos struct looks diffently than the linux one, use memset instead.

Also include string.h explicitly even std::string
is alredy used in this class.

It fixes #47 