### PR TITLE
Add missing include for uint8_t

### DIFF
--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -133,6 +133,7 @@ Deinitializer& operator << (Deinitializer& deinit, servicediscovery::avahi::Serv
 <% end %>
 
 <% if deployer.corba_enabled? %>
+#include <stdint.h>
 int sigint_com[2];
 void sigint_quit_orb(int)
 {


### PR DESCRIPTION
This popped up on an old lucid system but actually should be included if you want to use uint8_t, without relying on other headers.

Signed-off-by: Ruben Smits <ruben.smits@intermodalics.eu>