### PR TITLE
explicitely define #inspect on some classes

### DIFF
--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -533,6 +533,10 @@ module OroGen
                     raise Typelib::NotFound, "#{t} cannot be found in the currently loaded registries"
                 end
             end
+
+            def inspect
+                to_s
+            end
         end
     end
 end

--- a/lib/orogen/spec/deployment.rb
+++ b/lib/orogen/spec/deployment.rb
@@ -435,6 +435,13 @@ thread_#{name}->setMaxOverrun(#{max_overruns});
 	    # class (the default)
 	    def non_realtime; @realtime = false; self end
 
+            def to_s
+                "#<#{self.class} name=#{name} model=#{task_model}>"
+            end
+            def inspect
+                to_s
+            end
+
             def pretty_print(pp) # :nodoc:
                 pp.text "#{name}[#{task_model.name}]"
                 pp.nest(2) do
@@ -521,6 +528,14 @@ thread_#{name}->setMaxOverrun(#{max_overruns});
                 :info => 'Info',
                 :debug => 'Debug'
             }
+
+            def to_s
+                "#<#{self.class} name=#{name} tasks=#{task_activities.map { |t| "#{t}" }.join(", ")}>"
+            end
+
+            def inspect
+                to_s
+            end
 
             def uses_qt?
                 task_activities.any?{|t| t.task_model.uses_qt?}

--- a/lib/orogen/spec/project.rb
+++ b/lib/orogen/spec/project.rb
@@ -333,6 +333,10 @@ module OroGen
                 return enum_for(__method__) if !block_given?
                 deployers.each_value(&proc)
             end
+
+            def to_s
+                "#<#{self.class}: name=#{name} loader=#{loader}>"
+            end
         end
     end
 end


### PR DESCRIPTION
Calling #inspect on anything that was containing a Project or loader
was leading to pages and pages of text. Make it a lot simpler.