### PR TITLE
Fixed clang importer for double-types

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -1294,6 +1294,9 @@ module OroGen
                 if metadata.include?('orogen_include')
                     return metadata.get('orogen_include')
                 end
+                if(type <= Typelib::NumericType)
+                    return []
+                end
                 nil
             end
 


### PR DESCRIPTION
Otherwise /double was unknown in this code-block
which results to failures.

@marvin2k took a look already