### PR TITLE
spec: move the test on abstract? to the codegen part

### DIFF
--- a/lib/orogen/gen/deployment.rb
+++ b/lib/orogen/gen/deployment.rb
@@ -54,7 +54,15 @@ module OroGen
         class Deployment < Spec::Deployment
             def task(name, klass)
                 name = OroGen.verify_valid_identifier(name)
-                super(name, klass)
+                if klass.respond_to?(:to_str)
+                    task_context = project.task_model_from_name(klass)
+                else task_context = klass
+                end
+
+                if task_context.abstract?
+                    raise ArgumentError, "cannot create a deployment for #{task_context.name}, as it is abstract"
+                end
+                super(name, task_context)
             end
 
             def dependencies

--- a/lib/orogen/spec/deployment.rb
+++ b/lib/orogen/spec/deployment.rb
@@ -637,10 +637,6 @@ thread_#{name}->setMaxOverrun(#{max_overruns});
                 else task_context = klass
                 end
 
-                if task_context.abstract?
-                    raise ArgumentError, "cannot create a deployment for #{task_context.name}, as it is abstract"
-                end
-
                 if find_task_by_name(name)
                     raise ArgumentError, "there is already a task #{name} on the deployment #{self.name}"
                 end


### PR DESCRIPTION
This really is a specificity of the C++ code generator. Defining a
deployment that has an abstract task is not a problem. Instanciating
it (i.e. trying to run it) is / might be.