### PR TITLE
opaque type equality should be checked by typename instead of type member equality

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -375,7 +375,7 @@ module OroGen
                 type = find_type(type_def)
                 raise "#{type} is unknown" unless type
                 raise "#{type} is not opaque" unless type.opaque?
-                if result = opaques.find { |opaque_def| opaque_def.type == type }
+                if result = opaques.find { |opaque_def| opaque_def.type.eql? type }
 		    result
 		else
 		    raise InternalError, "#{self}#opaque_specification called for type #{type.name}, but could not find the corresponding opaque specification"
@@ -411,7 +411,7 @@ module OroGen
                         end
                         @intermediate_to_opaque[type.name]
                     end
-                elsif opaque_def = opaques.find { |spec| find_type(spec.intermediate, true) == type }
+                elsif opaque_def = opaques.find { |spec| find_type(spec.intermediate, true).eql? type }
                     opaque_def.type
                 end
             end

--- a/lib/orogen/spec/typekit.rb
+++ b/lib/orogen/spec/typekit.rb
@@ -131,7 +131,7 @@ module OroGen
                 type = resolve_type(type_def)
                 raise "#{type} is unknown" unless type
                 raise "#{type} is not opaque" unless type.opaque?
-                if result = opaques.find { |opaque_def| opaque_def.type == type }
+                if result = opaques.find { |opaque_def| opaque_def.type.eql? type }
 		    result
 		else
 		    raise InternalError, "#{self}#opaque_specification called for type #{type.name}, but could not find the corresponding opaque specification"
@@ -167,7 +167,7 @@ module OroGen
                         end
                         @intermediate_to_opaque[type.name]
                     end
-                elsif opaque_def = opaques.find { |spec| resolve_type(spec.intermediate) == type }
+                elsif opaque_def = opaques.find { |spec| resolve_type(spec.intermediate).eql? type }
                     opaque_def.type
                 end
             end


### PR DESCRIPTION
Currently opaque type equality is checked using the == operator which calls `do_compare` in typelib. And I guess that it is intentional that it checks for equal member types and offsets and doesn't check the name of the type.

But in the case two opaques are defined having the same members. E.g.:
```
struct ClassAWrapper
{
    std::vector<uint8_t> bin;
};

struct ClassBWrapper
{
    std::vector<uint8_t> bin;
};
```
they currently both resolve in the same opaque type ClassA.
So I think comparing the type name instead of the type would be the right thing to do here.