### PR TITLE
typekit.rb: forward compiler defines when loading types

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -1499,6 +1499,13 @@ module OroGen
                 # earlier) so that the importer can fill-in some of the
                 # metadata, like doc and source_file_line.
                 options[:include_paths] = include_dirs
+                
+                #if the user defined additional compiler defines, hand them over to the importer 
+                #because defines might change how the code looks (e.g. some methods might be ifdef guarded)
+                unless preprocess_options[:define].nil? 
+                    options[:define] = preprocess_options[:define]
+                end
+
 
                 include_mappings.each do |file, lines|
                     lines.map! { |inc| pending_loads_to_relative[inc] }

--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -1501,11 +1501,8 @@ module OroGen
                 options[:include_paths] = include_dirs
                 
                 #if the user defined additional compiler defines, hand them over to the importer 
-                #because defines might change how the code looks (e.g. some methods might be ifdef guarded)
-                unless preprocess_options[:define].nil? 
-                    options[:define] = preprocess_options[:define]
-                end
-
+                #because defines might change how the code looks (e.g. some methods might be #ifdef guarded)
+                options[:define] = preprocess_options[:define]
 
                 include_mappings.each do |file, lines|
                     lines.map! { |inc| pending_loads_to_relative[inc] }


### PR DESCRIPTION
Forwarding the defines is necessary because the clang importer needs them to parse some headers correctly.