### PR TITLE
missing std to parse this orogen file

### DIFF
--- a/misc/new_project/NAME.orogen
+++ b/misc/new_project/NAME.orogen
@@ -15,6 +15,7 @@ import_types_from "NAMETypes.hpp"
 
 # If this project uses data types that are defined in other oroGen projects,
 # these projects should be imported there as well.
+import_types_from "std"
 # import_types_from "base"
 
 # Declare a new task context (i.e., a component)


### PR DESCRIPTION
IMO this template orogen file should import 'std' since it is used in the ports.
Otherwise when executing:
$ orogen create example && cd example
$ orogen example.orogen
The orogen parser reports:
===== Internal error =======
Please report the following error to the orogen developers
~/dev/tools/orogen/lib/orogen/gen/typekit.rb:2189:in `include_for_type': while rendering tasks/TaskBase.hpp: no includes known for /int32_t defined in [] (OroGen::InternalError)
