### PR TITLE
loaders: use metadata to store opaque information on load

### DIFF
--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -259,8 +259,30 @@ module OroGen
                 end
 
                 registry.merge typekit.registry
+
+                typekit.registry.each(with_aliases: false) do |type|
+                    self_type = registry.get(type.name)
+                    self_type.metadata.add('orogen:typekits', typekit.name)
+                    if typekit.include?(type.name)
+                        self_type.metadata.add('orogen:definition_typekits', typekit.name)
+                    end
+
+                    if type.contains_opaques?
+                        intermediate_type_name = typekit.intermediate_type_name_for(type)
+                        intermediate_type = registry.get(intermediate_type_name)
+                        self_type.metadata.add('orogen:intermediate_type',
+                                          intermediate_type_name)
+                        intermediate_type.metadata.add('orogen:intermediate_type_of',
+                                                       type.name)
+                        if !type.opaque?
+                            intermediate_type.metadata.set('orogen:generated_type',
+                                                           'true')
+                        end
+                    end
+                end
+
                 @interface_typelist |= typekit.interface_typelist
-                typekit.registry.each(:with_aliases => true) do |typename, _|
+                typekit.registry.each(with_aliases: true) do |typename, _|
                     typekits_by_type_name[typename] ||= Set.new
                     typekits_by_type_name[typename] << typekit
                 end
@@ -307,7 +329,7 @@ module OroGen
             rescue Typelib::NotFound => e
                 if define_dummy_types? || options[:define_dummy_type]
                     type = registry.create_null(typename)
-                    interface_typelist << typename
+                    register_type_model(type, interface: true)
                     return type
                 else raise e, "#{e.message} using #{self}", e.backtrace
                 end
@@ -368,8 +390,7 @@ module OroGen
             # @param (see Spec::Typekit#intermediate_type?)
             # @return (see Spec::Typekit#intermediate_type?)
             def intermediate_type?(type)
-                imported_typekits_for(type, definition_typekits: false).
-                    any? { |tk| tk.intermediate_type?(type) }
+                !type.metadata.get('orogen:intermediate_type_of').empty?
             end
 
             # Returns the opaque type that is paired with the given type
@@ -378,9 +399,8 @@ module OroGen
             # @raise (see Spec::Typekit#opaque_type_for)
             # @return (see Spec::Typekit#opaque_type_for)
             def opaque_type_for(type)
-                type = imported_typekits_for(type, definition_typekits: false).
-                    first.opaque_type_for(type)
-                registry.get(type.name)
+                opaques = type.metadata.get('orogen:intermediate_type_of')
+                registry.get(opaques.first || type.name)
             end
 
             # Returns the intermediate type that is paired with the given type
@@ -389,9 +409,8 @@ module OroGen
             # @raise (see Spec::Typekit#opaque_type_for)
             # @return (see Spec::Typekit#opaque_type_for)
             def intermediate_type_for(type)
-                type = imported_typekits_for(type, definition_typekits: false).
-                    first.intermediate_type_for(type)
-                registry.get(type.name)
+                intermediates = type.metadata.get('orogen:intermediate_type')
+                registry.get(intermediates.first || type.name)
             end
 
             # Returns whether this type is a m-type (intermediate type generated
@@ -401,8 +420,7 @@ module OroGen
             # @raise (see Spec::Typekit#m_type?)
             # @return (see Spec::Typekit#m_type?)
             def m_type?(type)
-                imported_typekits_for(type, definition_typekits: false).
-                    first.m_type?(type)
+                type.metadata.get('orogen:generated_type') == ['true']
             end
 
             # Registers this project's subobjects

--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -390,6 +390,7 @@ module OroGen
             # @param (see Spec::Typekit#intermediate_type?)
             # @return (see Spec::Typekit#intermediate_type?)
             def intermediate_type?(type)
+                type = resolve_type(type)
                 !type.metadata.get('orogen:intermediate_type_of').empty?
             end
 
@@ -399,6 +400,7 @@ module OroGen
             # @raise (see Spec::Typekit#opaque_type_for)
             # @return (see Spec::Typekit#opaque_type_for)
             def opaque_type_for(type)
+                type = resolve_type(type)
                 opaques = type.metadata.get('orogen:intermediate_type_of')
                 registry.get(opaques.first || type.name)
             end
@@ -409,6 +411,7 @@ module OroGen
             # @raise (see Spec::Typekit#opaque_type_for)
             # @return (see Spec::Typekit#opaque_type_for)
             def intermediate_type_for(type)
+                type = resolve_type(type)
                 intermediates = type.metadata.get('orogen:intermediate_type')
                 registry.get(intermediates.first || type.name)
             end
@@ -420,6 +423,7 @@ module OroGen
             # @raise (see Spec::Typekit#m_type?)
             # @return (see Spec::Typekit#m_type?)
             def m_type?(type)
+                type = resolve_type(type)
                 type.metadata.get('orogen:generated_type') == ['true']
             end
 

--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -322,14 +322,12 @@ module OroGen
             #
             # @return [Set<Spec::Typekit>] the list of typekits
             # @raise [DefinitionTypekitNotFound] if no typekits define this type
-            def imported_typekits_for(typename, options = Hash.new)
-                options = Kernel.validate_options options,
-                    :definition_typekits => true
+            def imported_typekits_for(typename, definition_typekits: true)
 		if typename.respond_to?(:name)
 		    typename = typename.name
 		end
                 if typekits = typekits_by_type_name[typename]
-                    if options[:definition_typekits]
+                    if definition_typekits
                         definition_typekits = typekits.find_all { |tk| tk.include?(typename) }
                         if definition_typekits.empty?
                             raise DefinitionTypekitNotFound, "typekits #{typekits.map(&:name).sort.join(", ")} have #{typename} in their registries, but it seems that they got it from another typekit and I cannot find it. definition_typekits is true, I raise"

--- a/lib/orogen/test.rb
+++ b/lib/orogen/test.rb
@@ -14,7 +14,7 @@ if ENV['TEST_ENABLE_COVERAGE'] == '1'
 end
 
 require 'minitest/autorun'
-require 'flexmock/test_unit'
+require 'flexmock/minitest'
 require 'minitest/spec'
 require 'orogen'
 
@@ -59,11 +59,6 @@ module OroGen
             OroGen::Spec::Project.new(loader)
         end
 
-        if defined? FlexMock
-            include FlexMock::ArgumentTypes
-            include FlexMock::MockContainer
-        end
-
         def setup
             # Setup code for all the tests
         end
@@ -72,15 +67,6 @@ module OroGen
             # Teardown code for all the tests
         end
     end
-end
-
-# Workaround a problem with flexmock and minitest not being compatible with each
-# other (currently). See github.com/jimweirich/flexmock/issues/15.
-if defined?(FlexMock) && !FlexMock::TestUnitFrameworkAdapter.method_defined?(:assertions)
-    class FlexMock::TestUnitFrameworkAdapter
-        attr_accessor :assertions
-    end
-    FlexMock.framework_adapter.assertions = 0
 end
 
 module Minitest


### PR DESCRIPTION
The right solution, and one I hope someone will one day have
the time to implement, would be to store it at generation time.

In the meantime, use it in loaders to avoid attempting complex
resolutions over and over and over again.