### PR TITLE
load the RTT typekit after the std typekit so that orocos_type_name = typelib_type_name

### DIFF
--- a/lib/orogen/spec/configuration_object.rb
+++ b/lib/orogen/spec/configuration_object.rb
@@ -28,7 +28,9 @@ module OroGen
             def type_name; type.name end
 
             # The type name as registered on RTT
-            def orocos_type_name; Typelib::Registry.rtt_typename(type) end
+            def orocos_type_name
+                type.name
+            end
 
 	    # The property's default value
 	    attr_reader :default_value

--- a/lib/orogen/spec/port.rb
+++ b/lib/orogen/spec/port.rb
@@ -13,7 +13,7 @@ module OroGen
             def type_name; type.name end
             # The port name as it is registered on RTT
             def orocos_type_name
-                Typelib::Registry.rtt_typename(type)
+                type.name
             end
 
             # Converts this model into a representation that can be fed to e.g.

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -201,14 +201,6 @@ int ORO_main(int argc, char* argv[])
    }
    <% end %>
 
-   RTT::types::TypekitRepository::Import( new RTT::types::RealTimeTypekitPlugin );
-   <% if deployer.transports.include?('corba') %>
-   RTT::types::TypekitRepository::Import( new RTT::corba::CorbaLibPlugin );
-   <% end %>
-   <% if deployer.transports.include?('mqueue') %>
-   RTT::types::TypekitRepository::Import( new RTT::mqueue::MQLibPlugin );
-   <% end %>
-
    <% if project.typekit %>
    RTT::types::TypekitRepository::Import( new orogen_typekits::<%= project.name %>TypekitPlugin );
    <% deployer.transports.each do |transport_name| %>
@@ -221,6 +213,14 @@ int ORO_main(int argc, char* argv[])
        <% deployer.transports.each do |transport_name| %>
    RTT::types::TypekitRepository::Import( new <%= RTT_CPP::Typekit.transport_plugin_name(transport_name, tk.name) %> );
        <% end %>
+   <% end %>
+
+   RTT::types::TypekitRepository::Import( new RTT::types::RealTimeTypekitPlugin );
+   <% if deployer.transports.include?('corba') %>
+   RTT::types::TypekitRepository::Import( new RTT::corba::CorbaLibPlugin );
+   <% end %>
+   <% if deployer.transports.include?('mqueue') %>
+   RTT::types::TypekitRepository::Import( new RTT::mqueue::MQLibPlugin );
    <% end %>
 
 <% if deployer.corba_enabled? %>


### PR DESCRIPTION
Finally removing a little bit of horrible ugliness.

Must be merged at the same time than rock-core/tools-orocosrb#104