### PR TITLE
Recude redundant flags pkgconfig files

### DIFF
--- a/lib/orogen/templates/tasks/tasks.pc
+++ b/lib/orogen/templates/tasks/tasks.pc
@@ -26,11 +26,11 @@ Requires: @<%= project.name.upcase %>_TASKLIB_REQUIRES@
 %>
 Libs: <%= libs.to_a.sort.join(" ") %> -L${libdir} -l<%= project.name %>-tasks-<%= project.orocos_target %>
 <%
-  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.cflags if tk.pkg }.compact.to_set
-  cflags |= project.used_typekits.map { |tk| tk.pkg.cflags if tk.pkg }.compact.to_set
+  cflags = project.tasklib_used_task_libraries.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
+  cflags |= project.used_typekits.map { |tk| tk.pkg.raw_cflags if tk.pkg }.flatten.compact.to_set
 %>
 <% if project.extended_state_support? %>
 <%   cflags << "-I${includedir}/#{project.name}/types" %>
 <% end %>
-Cflags: -I${includedir} <%= cflags.to_a.sort.join(" ") %>
+Cflags: -I${includedir} <%= cflags.to_a.join(" ") %>
 

--- a/lib/orogen/templates/typekit/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/CMakeLists.txt
@@ -86,6 +86,7 @@ set(PKG_CFLAGS ${OrocosRTT_CFLAGS})
 set(PKG_CFLAGS ${PKG_CFLAGS} ${<%= dep_def.var_name %>_CFLAGS})
         <% end %>
     <% end %>
+list(REMOVE_DUPLICATES PKG_CFLAGS)
 string(REPLACE ";" "\" \"" PKG_CFLAGS "\"${PKG_CFLAGS}\"")
 
 # Generate the base typekit shared library


### PR DESCRIPTION
Trying to clean the autogenerated pkgconfig files a bit, since the pc files generated by orogen currently contain redundant flags and also quoted flags (is there really a need for the quoting?)