### PR TITLE
Fill empty license tag in package.xml template

### DIFF
--- a/lib/orogen/templates/typekit/package.xml
+++ b/lib/orogen/templates/typekit/package.xml
@@ -5,7 +5,7 @@
       <%= typekit.name %>-typekit description
     </description>
     <!--NOTE: set the license and author before you publish this code-->
-    <license></license>
+    <license>LGPLv2+</license>
     <author>Unknown Author</author>
     <maintainer email="unknown@maintainer.com">Unknown Author</maintainer>
 


### PR DESCRIPTION
This is necessary because an empty license tag is not valid. When trying to build a package that's using this template unmodified, catkin aborts with an error message saying that a license tag cannot be empty or contain only whitespace. This breaks the compilation of the ROS-Rock-bridge at the moment.