### PR TITLE
Forward cflags of loaded headers files to load options

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -1212,6 +1212,7 @@ module OroGen
                 include_path = include_dirs.map { |d| Pathname.new(d) }
                 inc = resolve_full_include_path_to_relative(file, include_path)
                 included_files << inc
+                user_options[:rawflags] = self.used_libraries.map do |lib| lib.raw_cflags end.flatten.uniq
 
                 this_options = [add, user_options]
                 if pending_load_options != this_options


### PR DESCRIPTION
This makes orogen eventually pass cflags to typegen. This was discussed at orocos-toolchain/typelib#99 when thinking about how to tell typegen which cpp copiler version to use (eg. `-std=c++11`).