### PR TITLE
pass subclass at task context creation

### DIFF
--- a/lib/orogen.rb
+++ b/lib/orogen.rb
@@ -42,6 +42,7 @@ require 'rexml/streamlistener'
 require 'rexml/document'
 
 require 'orogen/version'
+require 'orogen/warn_deprecated'
 require 'orogen/exceptions'
 require 'orogen/base'
 require 'orogen/check_for_stray_dots'

--- a/lib/orogen/loaders/rtt/OCL.orogen
+++ b/lib/orogen/loaders/rtt/OCL.orogen
@@ -6,13 +6,11 @@ context = external_task_context "ReportingComponent" do
     fixed_initial_state
 end
 
-external_task_context 'TCPReporting' do
-    subclasses "ReportingComponent"
+external_task_context 'TCPReporting', subclasses: 'ReportingComponent' do
     property 'port', 'int', 3142
 end
 
-external_task_context 'FileReporting' do
-    subclasses "ReportingComponent"
+external_task_context 'FileReporting', subclasses: 'ReportingComponent' do
     property 'ReportFile', 'std/string'
 end
 

--- a/lib/orogen/spec/project.rb
+++ b/lib/orogen/spec/project.rb
@@ -150,7 +150,7 @@ module OroGen
             #
             # Task contexts are represented as instances of TaskContext. See
             # the documentation of that class for more details.
-	    def task_context(name, options = Hash.new, &block)
+	    def task_context(name, subclasses: default_task_superclass, **options, &block)
                 if namespace_disabled?(name.split("::")[0..-2].join("::"))
                     return
                 end
@@ -163,7 +163,7 @@ module OroGen
 
                 name = OroGen.verify_valid_identifier(name)
 
-                task = external_task_context(name, options, &block)
+                task = external_task_context(name, subclasses: subclasses, **options, &block)
                 task.extended_state_support
                 self_tasks[task.name] = task
 
@@ -178,11 +178,10 @@ module OroGen
             #
             # @options options [Class] type ({TaskContext}) the
             #   class of the created task context
-            def external_task_context(name, options = Hash.new, &block)
-                options = Kernel.validate_options options,
-                    :class => TaskContext
+            def external_task_context(name, subclasses: default_task_superclass, **options, &block)
+                component_class = options.fetch(:class, TaskContext)
 
-		new_task = options[:class].new(self, "#{self.name}::#{name}")
+		new_task = component_class.new(self, "#{self.name}::#{name}", subclasses: subclasses)
 		new_task.instance_eval(&block) if block_given?
 		tasks[new_task.name] = new_task
                 loader.loaded_task_models[new_task.name] = new_task

--- a/lib/orogen/warn_deprecated.rb
+++ b/lib/orogen/warn_deprecated.rb
@@ -1,0 +1,6 @@
+module OroGen
+    def self.warn_deprecated(method_name, msg)
+        OroGen.warn "#{method_name} is deprecated: #{msg}"
+    end
+end
+

--- a/test/spec/test_task_context.rb
+++ b/test/spec/test_task_context.rb
@@ -173,7 +173,7 @@ describe OroGen::Spec::TaskContext do
         it "can enumerate states from the superclass" do
             superclass = project.task_context "Base"
             superclass.send("#{type}_states", "STATE0")
-            task.subclasses superclass
+            task = project.task_context 'Subtask', subclasses: superclass
             task.send("#{type}_states", "STATE1")
             assert_equal ["STATE0", "STATE1"], task.send("each_#{type}_state").to_a
         end
@@ -245,8 +245,7 @@ describe OroGen::Spec::TaskContext do
             attr_reader :parent_task
             before do
                 @parent_task = task
-                @task = OroGen::Spec::TaskContext.new(parent_task.project)
-                task.subclasses parent_task
+                @task = OroGen::Spec::TaskContext.new(parent_task.project, subclasses: parent_task)
             end
 
             describe "#each_dynamic_input_port" do


### PR DESCRIPTION
This fixes a longstanding problem between subclassing and plugins. Plugins are executed after the
TaskContext creation, but before the `subclass` statement. This means that they are not aware of
interface objects (properties, ports ...) that would be there because of the parent task context.

For instance, This leads to duplicate properties in the `orogen_metadata` plugin