### PR TITLE
Expose library path resolution code into loaders

### DIFF
--- a/lib/orogen/exceptions.rb
+++ b/lib/orogen/exceptions.rb
@@ -3,6 +3,8 @@ module OroGen
 
     class ProjectNotFound < NotFound; end
     class TypekitNotFound < NotFound; end
+    class TransportNotFound < NotFound; end
+    class LibraryNotFound < NotFound; end
     class DefinitionTypekitNotFound < TypekitNotFound; end
     class TaskModelNotFound < NotFound; end
     class TaskLibraryNotFound < NotFound; end

--- a/lib/orogen/gen/tasks.rb
+++ b/lib/orogen/gen/tasks.rb
@@ -52,7 +52,9 @@ EOF
         module PropertyGeneration
             include ConfigurationObjectGeneration
 
-            def used_types; [type] end
+            def used_types
+                each_interface_type.to_a
+            end
 
             def register_for_generation
                 constructor = []
@@ -77,7 +79,9 @@ EOF
         module AttributeGeneration
             include ConfigurationObjectGeneration
 
-            def used_types; [type] end
+            def used_types
+                each_interface_type.to_a
+            end
 
             def register_for_generation
                 constructor = []
@@ -98,9 +102,7 @@ EOF
         # Module that is used to add code generation functionality to Spec::Port
         module PortGeneration
             def used_types
-                if type then [type]
-                else []
-                end
+                each_interface_type.to_a
             end
 
             def register_for_generation
@@ -204,7 +206,7 @@ EOF
             # Returns the set of types that this operation uses, as a
             # Set of Typelib::Type classes.
             def used_types
-                [return_type.first].compact + arguments.map { |_, t, _| t }
+                each_interface_type.to_a
             end
 
 	    # Returns the argument part of the C++ signature for this callable
@@ -422,11 +424,8 @@ EOF
             # Returns the set of types that are used to define this task
             # context, as an array of subclasses of Typelib::Type.
             def interface_types
-                (all_properties + all_attributes + all_operations + all_ports + all_dynamic_ports).
-                    map { |obj| obj.used_types }.
-                    flatten.to_set.to_a
+                each_interface_type.to_a
             end
-
 
             # Returns the set of typekits that define the types used in this
             # task's interface. They are required at compile and link time

--- a/lib/orogen/loaders/aggregate.rb
+++ b/lib/orogen/loaders/aggregate.rb
@@ -140,11 +140,11 @@ module OroGen
             end
 
             def has_typekit?(name)
-                loaders.any? { |l| l.has_typekit?(name) }
+                super || loaders.any? { |l| l.has_typekit?(name) }
             end
 
             def has_project?(name)
-                loaders.any? { |l| l.has_project?(name) }
+                super || loaders.any? { |l| l.has_project?(name) }
             end
 
             # Enumerates the names of all available projects

--- a/lib/orogen/loaders/base.rb
+++ b/lib/orogen/loaders/base.rb
@@ -84,8 +84,11 @@ module OroGen
                 name = name.to_str
 
                 text, path = project_model_text_from_name(name)
-
                 OroGen.info "loading oroGen project #{name}"
+                project_model_from_text(text, name: name, path: path)
+            end
+
+            def project_model_from_text(text, name: nil, path: nil)
                 project = Spec::Project.new(root_loader)
                 project.typekit =
                     if has_typekit?(name)
@@ -95,8 +98,8 @@ module OroGen
                     end
 
                 Loaders::Project.new(project).__eval__(path, text)
-                if project.name != name
-                    raise InternalError, "inconsistency: got project #{project.name} while loading #{name}"
+                if name && (project.name != name)
+                    raise ArgumentError, "got project #{project.name} while loading #{name}"
                 end
                 register_project_model(project)
                 project
@@ -495,7 +498,7 @@ module OroGen
             # @param [String] name the project name
             # @return [Boolean]
             def has_project?(name)
-                raise NotImplementedError
+                loaded_projects.has_key?(name)
             end
 
             # Tests if a typekit with that name exists
@@ -503,7 +506,7 @@ module OroGen
             # @param [String] name the typekit name
             # @return [Boolean]
             def has_typekit?(name)
-                raise NotImplementedError
+                loaded_typekits.has_key?(name)
             end
 
             # Returns the task library name in which a task model is defined

--- a/lib/orogen/loaders/files.rb
+++ b/lib/orogen/loaders/files.rb
@@ -90,6 +90,15 @@ module OroGen
                 nil
             end
 
+            def find_task_library_from_task_model_name(name)
+                each_project do |project|
+                    if project.find_task_context(name)
+                        return project.name
+                    end
+                end
+                nil
+            end
+
             def find_project_from_deployment_name(name)
                 each_project do |project|
                     if project.find_deployment_by_name(name)

--- a/lib/orogen/loaders/pkg_config.rb
+++ b/lib/orogen/loaders/pkg_config.rb
@@ -94,7 +94,9 @@ module OroGen
             end
 
             def has_project?(name)
-                if available_projects.has_key?(name)
+                if super
+                    true
+                elsif available_projects.has_key?(name)
                     available_projects[name]
                 else
                     available_projects[name] = has_pkgconfig?("orogen-project-#{name}")
@@ -102,7 +104,9 @@ module OroGen
             end
 
             def has_typekit?(name)
-                if available_typekits.has_key?(name)
+                if super
+                    true
+                elsif available_typekits.has_key?(name)
                     available_typekits[name]
                 elsif !has_pkgconfig?("#{name}-typekit-#{orocos_target}")
                     available_typekits[name] = false

--- a/lib/orogen/loaders/pkg_config.rb
+++ b/lib/orogen/loaders/pkg_config.rb
@@ -288,7 +288,7 @@ module OroGen
             end
 
             def find_deployments_from_deployed_task_name(name)
-                if !available_deployed_tasks
+                if available_deployed_tasks.empty?
                     load_available_deployed_tasks
                 end
 
@@ -408,7 +408,7 @@ module OroGen
             def each_available_deployed_task_name(&block)
                 return enum_for(__method__) if !block_given?
 
-                if !available_deployed_tasks
+                if available_deployed_tasks.empty?
                     load_available_deployed_tasks
                 end
                 available_deployed_tasks.each do |deployed_task_name, deployments|

--- a/lib/orogen/loaders/pkg_config.rb
+++ b/lib/orogen/loaders/pkg_config.rb
@@ -1,5 +1,22 @@
 module OroGen
     module Loaders
+        @macos =  RbConfig::CONFIG["host_os"] =~%r!([Dd]arwin)!
+        def self.macos?
+            @macos
+        end
+
+        @windows = RbConfig::CONFIG["host_os"] =~%r!(msdos|mswin|djgpp|mingw|[Ww]indows)!
+        def self.windows?
+            @windows
+        end
+
+        def self.shared_library_suffix
+            if macos? then 'dylib'
+            elsif windows? then 'dll'
+            else 'so'
+            end
+        end
+
         # A loader that accesses the information from the pkg-config files
         # installed by oroGen.
         #
@@ -116,11 +133,11 @@ module OroGen
 
             def typekit_model_text_from_name(name)
                 begin
-                    pkg = Utilrb::PkgConfig.get("#{name}-typekit-#{orocos_target}", minimal: true)
+                    pkg = resolve_typekit_package(name, minimal: true)
                     available_typekits[name] = true
-                rescue Utilrb::PkgConfig::NotFound
+                rescue TypekitNotFound
                     available_typekits[name] = false
-                    raise TypekitNotFound, "cannot find a typekit called #{name}"
+                    raise
                 end
 
                 registry = File.read(pkg.type_registry)
@@ -148,6 +165,77 @@ module OroGen
                 else
                     available_task_models[model_name] = nil
                 end
+            end
+
+            # Return the pkgconfig description for a given task library package
+            #
+            # @param [String] name
+            # @return [Utilrb::PkgConfig] the package
+            # @raise TaskLibraryNotFound if the package cannot be found
+            def resolve_task_library_package(name, minimal: false)
+                Utilrb::PkgConfig.get("#{name}-tasks-#{orocos_target}", minimal: minimal)
+            rescue Utilrb::PkgConfig::NotFound
+                raise TaskLibraryNotFound, "the '#{name}' typekit is not available to pkgconfig"
+            end
+
+            # Return the pkgconfig description for a given typekit package
+            #
+            # @param [String] name
+            # @return [Utilrb::PkgConfig] the package
+            # @raise TypekitNotFound if the package cannot be found
+            def resolve_typekit_package(name, minimal: false)
+                Utilrb::PkgConfig.get("#{name}-typekit-#{orocos_target}", minimal: minimal)
+            rescue Utilrb::PkgConfig::NotFound
+                raise TypekitNotFound, "the '#{name}' typekit is not available to pkgconfig"
+            end
+
+            # Return the pkgconfig description for a given transport package
+            #
+            # @param [String] name
+            # @return [Utilrb::PkgConfig] the package
+            # @raise TransportNotFound if the package cannot be found
+            def resolve_transport_package(typekit_name, transport_name, minimal: false)
+                Utilrb::PkgConfig.get("#{typekit_name}-transport-#{transport_name}-#{orocos_target}", minimal: minimal)
+            rescue Utilrb::PkgConfig::NotFound
+                raise TransportNotFound, "the '#{transport_name}' transport for the '#{typekit_name}' typekit is not available to pkgconfig"
+            end
+
+            # @api private
+            # 
+            # Resolve the full path to a library from a pkg-config package
+            #
+            # @param [Utilrb::PkgConfig] package the package whose library dirs
+            #   will be used for resolution
+            # @param [String] library_name the library name, without a possible
+            #   "lib" prefix and the platform-specific suffix
+            # @return [String] the resolved path
+            # @raise LibraryNotFound if the library cannot be found
+            def resolve_package_library(package, library_name)
+                libname = "lib#{library_name}.#{Loaders.shared_library_suffix}"
+                package.library_dirs.each do |dir|
+                    if File.exist?(path = File.join(dir, libname))
+                        return path
+                    end
+                end
+                raise LibraryNotFound, "cannot find #{library_name} from #{package.name}"
+            end
+
+            # Return the full path to a task library's installed shared library
+            def task_library_path_from_name(tasklib_name)
+                libpkg = resolve_task_library_package(tasklib_name)
+                resolve_package_library(libpkg, libpkg.name)
+            end
+
+            # Return the full path to a typekit's installed shared library
+            def typekit_library_path_from_name(typekit_name)
+                libpkg = resolve_typekit_package(typekit_name)
+                resolve_package_library(libpkg, libpkg.name)
+            end
+
+            # Return the full path to a transport's installed shared library
+            def transport_library_path_from_name(typekit_name, transport_name)
+                libpkg = resolve_transport_package(typekit_name, transport_name)
+                resolve_package_library(libpkg, libpkg.name)
             end
 
             DeploymentInfo = Struct.new :project_name, :binfile

--- a/lib/orogen/spec/configuration_object.rb
+++ b/lib/orogen/spec/configuration_object.rb
@@ -79,6 +79,11 @@ module OroGen
                 pp.text "#{name}:#{type.name}#{default}"
             end
 
+            def each_interface_type
+                return enum_for(__method__) if !block_given?
+                yield type
+            end
+
 	    # call-seq:
 	    #	doc new_doc -> self
             #	doc ->  current_doc

--- a/lib/orogen/spec/dynamic_ports.rb
+++ b/lib/orogen/spec/dynamic_ports.rb
@@ -15,6 +15,11 @@ module OroGen
 
             def dynamic?; true end
 
+            def each_interface_type
+                return enum_for(__method__) if !block_given?
+                super if type
+            end
+
             def pretty_print(pp)
                 pp.text "[dyn,#{self.class < InputPort ? "in" : "out"}]#{name}:#{if type then type.name else "any type" end}"
             end

--- a/lib/orogen/spec/operation.rb
+++ b/lib/orogen/spec/operation.rb
@@ -60,6 +60,16 @@ module OroGen
                 super()
 	    end
 
+            def each_interface_type
+                return enum_for(__method__) if !block_given?
+                if ret = return_type.first
+                    yield(ret)
+                end
+                arguments.each do |_, t, _|
+                    yield(t)
+                end
+            end
+
             # Declares that the C++ method associated with this operation should
             # be executed in the caller thread (default is callee thread)
             #

--- a/lib/orogen/spec/port.rb
+++ b/lib/orogen/spec/port.rb
@@ -16,6 +16,11 @@ module OroGen
                 type.name
             end
 
+            def each_interface_type
+                return enum_for(__method__) if !block_given?
+                yield type
+            end
+
             # Converts this model into a representation that can be fed to e.g.
             # a JSON dump, that is a hash with pure ruby key / values.
             #

--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -1381,6 +1381,21 @@ module OroGen
                     operations: each_operation.map(&:to_h)
                 ]
             end
+
+            # Enumerate all the types that are used on this component's
+            # interface
+            def each_interface_type
+                return enum_for(__method__) if !block_given?
+
+                seen = Set.new
+                (all_properties + all_attributes + all_operations + all_ports + all_dynamic_ports).
+                    each do |obj|
+                        if !seen.include?(obj)
+                            obj.each_interface_type { |t| yield(t) }
+                            seen << obj
+                        end
+                    end
+            end
 	end
     end
 end

--- a/test/loaders/test_aggregate.rb
+++ b/test/loaders/test_aggregate.rb
@@ -1,0 +1,41 @@
+require 'orogen/test'
+
+describe OroGen::Loaders::Aggregate do
+    before do
+        @loader = OroGen::Loaders::Aggregate.new
+    end
+
+    describe "#has_project?" do
+        it "returns false by default" do
+            refute @loader.has_project?('does_not_exist')
+        end
+        it "returns true if the project exists on one of its children" do
+            @loader.add(child = OroGen::Loaders::Base.new)
+            flexmock(child).should_receive(:has_project?).with('test').and_return(true)
+            assert @loader.has_project?('test')
+        end
+        it "returns true if the project has been directly registered" do
+            @loader.project_model_from_text(<<-END)
+            name 'directly_registered'
+            END
+            assert @loader.has_project?('directly_registered')
+        end
+    end
+
+    describe "#has_typekit?" do
+        it "returns false by default" do
+            refute @loader.has_typekit?('does_not_exist')
+        end
+        it "returns true if the typekit exists on one of its children" do
+            @loader.add(child = OroGen::Loaders::Base.new)
+            flexmock(child).should_receive(:has_typekit?).with('test').and_return(true)
+            assert @loader.has_typekit?('test')
+        end
+        it "returns true if the typekit has been directly registered" do
+            typekit = OroGen::Spec::Typekit.new(nil, 'directly_registered')
+            @loader.register_typekit_model(typekit)
+            assert @loader.has_typekit?('directly_registered')
+        end
+    end
+end
+

--- a/test/loaders/test_pkg_config.rb
+++ b/test/loaders/test_pkg_config.rb
@@ -381,5 +381,104 @@ describe OroGen::Loaders::PkgConfig do
             assert_raises(OroGen::TypekitNotFound) { loader.typekit_model_text_from_name('base') }
         end
     end
+
+    describe "#task_library_path_from_name" do
+        before do
+            FileUtils.mkdir_p(@env_dir = Dir.mktmpdir)
+            @loader = OroGen::Loaders::PkgConfig.new('oroarch')
+        end
+        after do
+            FileUtils.rm_rf @env_dir
+        end
+
+        it "resolves an existing library from the pkg-config description" do
+            pkg  = flexmock(name: 'test-tasks-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-tasks-oroarch.so')
+            FileUtils.touch path
+            stub_pkgconfig_package 'test-tasks-oroarch', pkg
+            assert_equal path, @loader.task_library_path_from_name('test')
+        end
+
+        it "raises if the task library does not exist" do
+            assert_raises(OroGen::TaskLibraryNotFound) do
+                @loader.task_library_path_from_name('test')
+            end
+        end
+
+        it "raises if the library cannot be found on disk" do
+            pkg  = flexmock(name: 'test-tasks-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-tasks-oroarch.so')
+            stub_pkgconfig_package 'test-tasks-oroarch', pkg
+            assert_raises(OroGen::LibraryNotFound) do
+                @loader.task_library_path_from_name('test')
+            end
+        end
+    end
+
+    describe "#typekit_library_path_from_name" do
+        before do
+            FileUtils.mkdir_p(@env_dir = Dir.mktmpdir)
+            @loader = OroGen::Loaders::PkgConfig.new('oroarch')
+        end
+        after do
+            FileUtils.rm_rf @env_dir
+        end
+
+        it "resolves an existing library from the pkg-config description" do
+            pkg  = flexmock(name: 'test-typekit-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-typekit-oroarch.so')
+            FileUtils.touch path
+            stub_pkgconfig_package 'test-typekit-oroarch', pkg
+            assert_equal path, @loader.typekit_library_path_from_name('test')
+        end
+
+        it "raises if the typekit does not exist" do
+            assert_raises(OroGen::TypekitNotFound) do
+                @loader.typekit_library_path_from_name('test')
+            end
+        end
+
+        it "raises if the library cannot be found on disk" do
+            pkg  = flexmock(name: 'test-typekit-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-typekit-oroarch.so')
+            stub_pkgconfig_package 'test-typekit-oroarch', pkg
+            assert_raises(OroGen::LibraryNotFound) do
+                @loader.typekit_library_path_from_name('test')
+            end
+        end
+    end
+
+    describe "#transport_library_path_from_name" do
+        before do
+            FileUtils.mkdir_p(@env_dir = Dir.mktmpdir)
+            @loader = OroGen::Loaders::PkgConfig.new('oroarch')
+        end
+        after do
+            FileUtils.rm_rf @env_dir
+        end
+
+        it "resolves an existing library from the pkg-config description" do
+            pkg  = flexmock(name: 'test-transport-trsp-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-transport-trsp-oroarch.so')
+            FileUtils.touch path
+            stub_pkgconfig_package 'test-transport-trsp-oroarch', pkg
+            assert_equal path, @loader.transport_library_path_from_name('test', 'trsp')
+        end
+
+        it "raises if the transport does not exist" do
+            assert_raises(OroGen::TransportNotFound) do
+                @loader.transport_library_path_from_name('test', 'trsp')
+            end
+        end
+
+        it "raises if the library cannot be found on disk" do
+            pkg  = flexmock(name: 'test-transport-trsp-oroarch', library_dirs: [@env_dir])
+            path = File.join(@env_dir, 'libtest-transport-trsp-oroarch.so')
+            stub_pkgconfig_package 'test-transport-trsp-oroarch', pkg
+            assert_raises(OroGen::LibraryNotFound) do
+                @loader.transport_library_path_from_name('test', 'trsp')
+            end
+        end
+    end
 end
 

--- a/test/loaders/test_pkg_config.rb
+++ b/test/loaders/test_pkg_config.rb
@@ -69,11 +69,22 @@ describe OroGen::Loaders::PkgConfig do
             flexmock(Utilrb::PkgConfig).should_receive(:get).never
             assert !loader.has_project?('test')
         end
+        it "returns true if the project has been directly registered" do
+            loader.project_model_from_text(<<-END)
+            name 'directly_registered'
+            END
+            assert loader.has_project?('directly_registered')
+        end
     end
 
     describe "#has_typekit?" do
         let(:loader) { OroGen::Loaders::PkgConfig.new('oroarch') }
 
+        it "returns true if the typekit has been directly registered" do
+            typekit = OroGen::Spec::Typekit.new(nil, 'directly_registered')
+            loader.register_typekit_model(typekit)
+            assert loader.has_typekit?('directly_registered')
+        end
         it "returns true if the typekit is available and caches the result" do
             stub_orogen_pkgconfig 'base'
             stub_orogen_pkgconfig_final

--- a/test/loaders/test_pkg_config.rb
+++ b/test/loaders/test_pkg_config.rb
@@ -276,7 +276,7 @@ describe OroGen::Loaders::PkgConfig do
                 :deployed_tasks => "",
                 :path => "bla",
                 :binfile => '/path/to/binfile')
-            stub_pkgconfig_package("orogen-project-base", pkg)
+            stub_pkgconfig_package("base-tasks-oroarch", pkg)
             stub_orogen_pkgconfig_final
         end
         let(:loader) { OroGen::Loaders::PkgConfig.new('oroarch') }

--- a/test/spec/test_task_context.rb
+++ b/test/spec/test_task_context.rb
@@ -146,7 +146,7 @@ describe OroGen::Spec::TaskContext do
             assert_equal :runtime, task.state_kind('TEST')
         end
         it "returns nil if the state is not known" do
-            assert_equal nil, task.state_kind('test')
+            assert_nil task.state_kind('test')
         end
     end
 


### PR DESCRIPTION
The code for this was present in orocos.rb, but it's really an orogen-pkgconfig-specific code. Move
the functionality here to keep it close to orogen itself.