### PR TITLE
Fix typo in manifest.xml

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -19,8 +19,8 @@
     <depend package="metaruby" />
     <depend_optional package="hoe-yard" />
     <depend_optional package="kramdown" />
-    <depend name="rake" />
-    <depend name="ruby" />
+    <depend package="rake" />
+    <depend package="ruby" />
 
     <test_depend package="minitest" />
     <test_depend package="flexmock" />


### PR DESCRIPTION
The typo makes rosdep fail: https://github.com/ros-infrastructure/rosdep/issues/575