### PR TITLE
fix default extensions being enabled twice in imported projects

### DIFF
--- a/lib/orogen/spec/task_context.rb
+++ b/lib/orogen/spec/task_context.rb
@@ -64,25 +64,32 @@ module OroGen
                 #   the newly created task at creation time. This is meant to
                 #   register some default extensions automatically
                 attr_reader :default_extensions
-                attr_reader :extensions_disabled
 
-                def disable_default_extensions
-                    @extensions_disabled = true
+                def push_default_extensions_state(enabled)
+                    @default_extensions_state.push(enabled)
                 end
 
-                def enable_default_extensions
-                    @extensions_disabled = false
+                def pop_default_extensions_state
+                    @default_extensions_state.pop
+                end
+
+                def default_extensions_enabled?
+                    if @default_extensions_state.empty?
+                        true
+                    else
+                        @default_extensions_state.last
+                    end
                 end
 
                 def apply_default_extensions(task_context)
-                    if !extensions_disabled
-                        default_extensions.each do |ext|
-                            task_context.send(ext)
-                        end
+                    return unless default_extensions_enabled?
+
+                    default_extensions.each do |ext|
+                        task_context.send(ext)
                     end
                 end
             end
-            @extensions_disabled = false
+            @default_extensions_state = Array.new
             @default_extensions = Array.new
 
             enumerate_inherited_map 'default_extension', 'default_extensions'

--- a/lib/orogen/templates/project.orogen
+++ b/lib/orogen/templates/project.orogen
@@ -7,7 +7,7 @@ self.extended_states = <%= RTT_CPP.extended_states_enabled? %>
 self.disable_namespace "<%= d %>"
 <% end %>
 
-Spec::TaskContext.disable_default_extensions
+Spec::TaskContext.push_default_extensions_state(false)
 
 <% used_typekits.each do |tk| %>
 <%   if !tk.virtual? %>
@@ -24,4 +24,4 @@ find_task_context("<%= task_context.name %>").<%= ext %>
 <%    end %>
 <% end %>
 
-Spec::TaskContext.enable_default_extensions
+Spec::TaskContext.pop_default_extensions_state


### PR DESCRIPTION
If one has two layers of imports (i.e. project A imports B imports C),
then the last line of C's installed orogen file

   Spec::TaskContext.enable_default_extensions

was unconditionally enabling the extensions, which leads to the default
extensions being enabled in B (even though they should not).

Fix by using a push/pop model instead of a enable/disable model.

Fixes #114
Fixes https://github.com/rock-core/drivers-orogen-iodrivers_base/issues/18