### PR TITLE
Fix manifest.xml rosdep compatibility

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -19,8 +19,8 @@
     <depend package="metaruby" />
     <depend_optional package="hoe-yard" />
     <depend_optional package="kramdown" />
-    <depend package="rake" />
-    <depend package="ruby" />
+    <rosdep name="rake" />
+    <rosdep name="ruby" />
 
     <test_depend package="minitest" />
     <test_depend package="flexmock" />

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>orogen</name>
-  <version>1.1.1</version>
+  <version>2.9.0</version>
   <description>
     orogen offers a specification interface for components developped in the
     Orocos Realtime Toolkit. Moreover, it generates the specified modules,

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
     thus offering an easy and fast development process.
   </description>
   <author>Sylvain Joyeux/sylvain.joyeux@m4x.org</author>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">OCL Development Team</maintainer>
+  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
   <license>GPL v2 or later</license>
 
   <url>http://rock-robotics.org/documentation/orogen</url>

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
   <run_depend>rtt_typelib</run_depend>
   <run_depend>utilrb</run_depend>
   <run_depend>metaruby</run_depend>
-  <run_depend>nokogiri</run_depend>
   <run_depend>rake</run_depend>
   <run_depend>ruby</run_depend>
 


### PR DESCRIPTION
Follow-up on #111 (@NikolausDemmel).

Unfortunately the old format 1 of the ROS package manifest (`manifest.xml`) differentiates between ROS packages and third-party software provided by the operating system and managed by [rosdep](http://wiki.ros.org/rosdep): http://docs.ros.org/independent/api/rospkg/html/manifest_xml.html

Because `rake` and `ruby` are system dependencies and do not provide a ROS-compatible package manifest, the "correct" way to list them in `manifest.xml` would be
```xml
<rosdep name="ruby" />
<rosdep name="rake" />
```

The patch in #111 fixes the `InvalidManifest` exception, but [rosdep](http://wiki.ros.org/rosdep) is still not able to resolve and install the dependencies:
```
johannes@im-laptop-007:/opt/orocos/kinetic/src/orocos_toolchain$ rosdep install --from-path . -i --rosdistro kinetic
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
orogen: Missing resource rake
ROS path [0]=/opt/orocos/src/orocos_toolchain
ROS path [1]=/opt/ros/kinetic/share
```

Compatibility between AutoProj and ROS tools regarding interpretation of `manifest.xml` is a long-lasting issue (https://github.com/orocos-toolchain/utilrb/issues/5). Ideally ROS tools would simply ignore `manifest.xml` if `package.xml` is present, but this request has been denied for reasons of backwards compatibility (https://github.com/ros-infrastructure/rosdep/issues/353). As long as this is not the case, the `manifest.xml` files need to be compatible to the ROS conventions if we want to allow users to use tools like [rosdep](http://wiki.ros.org/rosdep), which implies distinguishing ROS and system dependencies using different tags. Luckily unknown tags like `<depend_optional>` or `<test_depend>` are simply ignored by rosdep instead of returning with an error, but still it fails to verify or install those deps.

Remaining commits are to synchronize dependencies, maintainer and version number in `package.xml` with the [toolchain-2.9](https://github.com/orocos-toolchain/orogen/tree/toolchain-2.9) branch.