### PR TITLE
remove support for passing an execution engine in the constructors

### DIFF
--- a/lib/orogen/templates/tasks/Task.cpp
+++ b/lib/orogen/templates/tasks/Task.cpp
@@ -9,11 +9,6 @@ using namespace <%= task.full_namespace %>;
 {
 }
 
-<%= task.basename %>::<%= task.basename %>(std::string const& name, RTT::ExecutionEngine* engine<%= ", TaskCore::TaskState initial_state" unless task.fixed_initial_state? %>)
-    : <%= task.basename %>Base(name, engine<%= ", initial_state" unless task.fixed_initial_state? %>)
-{
-}
-
 <%= task.basename %>::~<%= task.basename %>()
 {
 }

--- a/lib/orogen/templates/tasks/Task.hpp
+++ b/lib/orogen/templates/tasks/Task.hpp
@@ -39,13 +39,6 @@ namespace <%= space %>{
          */
         <%= task.basename %>(std::string const& name = "<%= task.name %>"<%= ", TaskCore::TaskState initial_state = Stopped" unless task.fixed_initial_state? %>);
 
-        /** TaskContext constructor for <%= task.basename %>
-         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
-         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
-         * <%= "\\param initial_state The initial TaskState of the TaskContext. Default is Stopped state." unless task.fixed_initial_state? %>
-         */
-        <%= task.basename %>(std::string const& name, RTT::ExecutionEngine* engine<%= ", TaskCore::TaskState initial_state = Stopped" unless task.fixed_initial_state? %>);
-
         /** Default deconstructor of <%= task.basename %>
          */
 	~<%= task.basename %>();

--- a/lib/orogen/templates/tasks/TaskBase.cpp
+++ b/lib/orogen/templates/tasks/TaskBase.cpp
@@ -39,11 +39,11 @@ using namespace <%= task.full_namespace%>;
 
 <%= task.basename %>Base::<%= task.basename %>Base(std::string const& name, RTT::ExecutionEngine* engine<%= ", TaskCore::TaskState state" unless task.fixed_initial_state? %>)
 <% if task.superclass.fixed_initial_state? %>
-    : ::<%= task.superclass.name %>(name, engine)
+    : ::<%= task.superclass.name %>(name)
 <% elsif task.needs_configuration? %>
-    : ::<%= task.superclass.name %>(name, engine, TaskCore::PreOperational)
+    : ::<%= task.superclass.name %>(name, TaskCore::PreOperational)
 <% else %>
-    : ::<%= task.superclass.name %>(name, engine, state)
+    : ::<%= task.superclass.name %>(name, state)
 <% end %>
 <%= initializer_list %>
 {


### PR DESCRIPTION
RTT master just removed the execution engine, and we never actually used
that particular constructor. Deployments only use the constructor without the engine.
Remove support for setting it at all.

Just keep a constructor in TaskBase to keep older components compile.