### PR TITLE
fix include path used during IDL generation in some recursive cases

### DIFF
--- a/lib/orogen/gen/imports.rb
+++ b/lib/orogen/gen/imports.rb
@@ -22,7 +22,7 @@ module OroGen
                     # to handle following patterns:
                     # /string
                     # /unsigned char[8]
-                    # /unsigned char[8] 0 
+                    # /unsigned char[8] 0
                     if decl =~ /^(.*) (\d)$/
                         type, is_interface = $1, ($2 == '1')
                     else

--- a/lib/orogen/gen/imports.rb
+++ b/lib/orogen/gen/imports.rb
@@ -100,8 +100,14 @@ module OroGen
                 pkg.name
             end
             def perform_pending_loads; end
+            def transport_pkg(transport_name)
+                pkg_name = pkg.name.gsub(
+                    /typekit-(\w+)$/, "transport-#{transport_name}-\\1"
+                )
+                Utilrb::PkgConfig.new(pkg_name)
+            end
             def pkg_transport_name(transport_name)
-                Utilrb::PkgConfig.new(pkg.name.gsub('typekit', "transport-#{transport_name}")).name
+                transport_pkg(transport_name).name
             end
             def pkg_corba_name
                 pkg_transport_name('corba')

--- a/lib/orogen/gen/project.rb
+++ b/lib/orogen/gen/project.rb
@@ -1127,7 +1127,11 @@ module OroGen
                 end
                 tasklib
             end
-            
+
+            def orogen_typekit_package(name)
+                Utilrb::PkgConfig.new("#{name}-typekit-#{orocos_target}")
+            end
+
             # Returns the description information for the given typekit
             def orogen_typekit_description(name)
                 if description = @known_typekits[name]
@@ -1135,7 +1139,7 @@ module OroGen
                 end
 
                 pkg = begin
-                          Utilrb::PkgConfig.new("#{name}-typekit-#{orocos_target}")
+                          orogen_typekit_package(name)
                       rescue Utilrb::PkgConfig::NotFound => e
                           raise ConfigError, "no typekit named '#{name}' is available (could not load pkg-config info #{name}-typekit-#{orocos_target} in #{ENV['PKG_CONFIG_PATH']})"
                       end

--- a/lib/orogen/gen/project.rb
+++ b/lib/orogen/gen/project.rb
@@ -70,7 +70,7 @@ module OroGen
         #
         # Toplevel statements in the .orogen files are instance methods on a
         # Project instance. For instance, the
-        #   
+        #
         #   task_context "Name" do
         #      ...
         #   end
@@ -87,7 +87,7 @@ module OroGen
             attr_reader :tasks
 
             # A set of TaskContext instances listing the tasks defined in this
-            # project. 
+            # project.
             #
             # See #tasks for the set of all task definitions available in the
             # project.
@@ -569,7 +569,7 @@ module OroGen
             def resolve_type(typename)
                 find_type(typename)
             end
-            
+
             # Find the Typelib::Type object for +name+. +name+ can be either a
             # Typelib::Type object directly, or a type name. In both cases, the
             # type must have been defined either by the project's own typekit
@@ -868,7 +868,7 @@ module OroGen
                 end
                 self
             rescue Utilrb::PkgConfig::NotFound => e
-                if e.name == name 
+                if e.name == name
                     raise ConfigError, "no library named '#{name}' available", e.backtrace
                 else
                     raise ConfigError, "a dependency of library '#{name}' is not available: library '#{e.name}' could not be found", e.backtrace
@@ -1104,10 +1104,10 @@ module OroGen
                 end
                 loaded_deployments[name] = deployment
             end
-            
+
             # Called to store a loaded project for reuse later
             def register_loaded_project(name, obj)
-                OroGen.info "registering oroGen project #{name}" 
+                OroGen.info "registering oroGen project #{name}"
                 loaded_orogen_projects[name] = obj
             end
 

--- a/lib/orogen/gen/templates.rb
+++ b/lib/orogen/gen/templates.rb
@@ -1,194 +1,200 @@
 module OroGen
     module Gen
-        module RTT_CPP
-        AUTOMATIC_AREA_NAME = '.orogen'
+        module RTT_CPP # rubocop:disable Naming/ClassAndModuleCamelCase
+            AUTOMATIC_AREA_NAME = '.orogen'.freeze
 
-        @templates = Hash.new
-        class << self
-            # The set of templates already loaded as a path => ERB object hash
-            attr_reader :templates
-        end
-
-        # Returns the directory where oroGen's lib part sits, i.e.
-        # base_dir is defined by the directory where orogen.rb resides
-        def self.base_dir
-            File.expand_path(File.join('..', '..'), File.dirname(__FILE__))
-        end
-
-        # call-seq:
-        #   template_path(path1, path2, ..., file_name)
-        #
-        # Returns the full path for the template path1/path2/.../file_name.
-        # Templates names are the path relative to the template base directory,
-        # which is the orocos/templates directory directly in orogen sources.
-        #
-        # Alternative, if an absolute path it passed, it will be directly returned
-        def self.template_path(*path)
-            if Pathname.new(File.join(*path)).absolute?
-                File.join(*path)
-            else
-                reldir = File.join('orogen', 'templates', *path)
-                File.expand_path(reldir, base_dir)
-            end
-        end
-
-        # call-seq:
-        #   load_template path1, path2, ..., file_name => erb object
-        #
-        # Loads the template file located at
-        # template_dir/path1/path2/.../file_name and return the ERB object
-        # generated from it. template_dir is the templates/ directory located
-        # in Orocos.rb sources.
-        #
-        # A template is only loaded once. See Generation.templates.
-        def self.load_template(*path)
-            if template = templates[path]
-                template
-            else
-                template_file   = template_path(*path)
-
-                templates[path] = begin
-                                      ERB.new(File.read(template_file), nil, "<>", path.join('_').downcase.gsub(/[\/\.-]/, '_'))
-                                  rescue Errno::ENOENT
-                                      raise ArgumentError, "template #{File.join(*path)} does not exist"
-                                  end
-                templates[path].filename = template_file
-                templates[path]
-            end
-        end
-
-        # call-seq:
-        #   render_template path1, path2, file_name, binding
-        #
-        # Render the template found at path1/path2/file_name and render it
-        # using the provided binding
-        def self.render_template(*args)
-            binding = args.pop
-            template = load_template(*args)
-            debug "rendering #{File.join(*args)}"
-            template.result(binding)
-        rescue Exception => e
-            raise e, "while rendering #{File.join(*args)}: #{e.message}", e.backtrace
-        end
-
-        class << self
-            # The set of files generated so far, as a set of absolute paths
-            attr_reader :generated_files
-        end
-        @generated_files = Set.new
-
-        def self.save_generated(overwrite, *args) # :nodoc:
-            if args.size < 2
-                raise ArgumentError, "expected at least 2 arguments, got #{args.size}"
+            @templates = Hash.new
+            class << self
+                # The set of templates already loaded as a path => ERB object hash
+                attr_reader :templates
             end
 
-            data      = args.pop
-            file_path = File.expand_path(File.join(*args))
-            dir_name  = File.dirname(file_path)
-            FileUtils.mkdir_p(dir_name)
+            # Returns the directory where oroGen's lib part sits, i.e.
+            # base_dir is defined by the directory where orogen.rb resides
+            def self.base_dir
+                File.expand_path(File.join('..', '..'), File.dirname(__FILE__))
+            end
 
-            generated_files << file_path
-            if File.exists?(file_path)
-                if File.read(file_path) != data
-                    if overwrite
-                        info "  overwriting #{file_path}"
+            # call-seq:
+            #   template_path(path1, path2, ..., file_name)
+            #
+            # Returns the full path for the template path1/path2/.../file_name.
+            # Templates names are the path relative to the template base directory,
+            # which is the orocos/templates directory directly in orogen sources.
+            #
+            # Alternative, if an absolute path it passed, it will be directly returned
+            def self.template_path(*path)
+                if Pathname.new(File.join(*path)).absolute?
+                    File.join(*path)
+                else
+                    reldir = File.join('orogen', 'templates', *path)
+                    File.expand_path(reldir, base_dir)
+                end
+            end
+
+            # call-seq:
+            #   load_template path1, path2, ..., file_name => erb object
+            #
+            # Loads the template file located at
+            # template_dir/path1/path2/.../file_name and return the ERB object
+            # generated from it. template_dir is the templates/ directory located
+            # in Orocos.rb sources.
+            #
+            # A template is only loaded once. See Generation.templates.
+            def self.load_template(*path)
+                if template = templates[path]
+                    template
+                else
+                    template_file   = template_path(*path)
+
+                    templates[path] =
+                        begin
+                            ERB.new(File.read(template_file), nil, '<>',
+                                    path.join('_').downcase.gsub(%r{[\/\.-]}, '_'))
+                        rescue Errno::ENOENT
+                            raise ArgumentError, "template #{File.join(*path)} "\
+                                                 'does not exist'
+                        end
+                    templates[path].filename = template_file
+                    templates[path]
+                end
+            end
+
+            # call-seq:
+            #   render_template path1, path2, file_name, binding
+            #
+            # Render the template found at path1/path2/file_name and render it
+            # using the provided binding
+            def self.render_template(*args)
+                binding = args.pop
+                template = load_template(*args)
+                debug "rendering #{File.join(*args)}"
+                template.result(binding)
+            rescue RuntimeError => e
+                raise e, "while rendering #{File.join(*args)}: #{e.message}", e.backtrace
+            end
+
+            class << self
+                # The set of files generated so far, as a set of absolute paths
+                attr_reader :generated_files
+            end
+            @generated_files = Set.new
+
+            def self.save_generated(overwrite, *args) # :nodoc:
+                if args.size < 2
+                    raise ArgumentError, "expected at least 2 arguments, got #{args.size}"
+                end
+
+                data      = args.pop
+                file_path = File.expand_path(File.join(*args))
+                dir_name  = File.dirname(file_path)
+                FileUtils.mkdir_p(dir_name)
+
+                generated_files << file_path
+                if File.exist?(file_path)
+                    if File.read(file_path) != data
+                        if overwrite
+                            debug "  overwriting #{file_path}"
+                        else
+                            debug "  will not overwrite #{file_path}"
+                            return file_path
+                        end
                     else
-                        info "  will not overwrite #{file_path}"
+                        debug "  #{file_path} has not changed"
                         return file_path
                     end
                 else
-                    debug "  #{file_path} has not changed"
-                    return file_path
+                    debug "  creating #{file_path}"
                 end
-            else
-                info "  creating #{file_path}"
-            end
 
-            File.open(file_path, 'w') do |io|
-                io.write data
-            end
-            file_path
-        end
-
-        # call-seq:
-        #   save_automatic path1, path2, ..., file_name, data
-        #
-        # Save the provided data in the path1/path2/.../file_name file of the
-        # automatically-generated part of the project (i.e. under .orogen)
-        def self.save_automatic(*args)
-            save_generated true, AUTOMATIC_AREA_NAME, *args
-        end
-        
-        # call-seq:
-        #   save_public_automatic path1, path2, ..., file_name, data
-        #
-        # Save the provided data in the path1/path2/file_name file of the
-        # user-written part of the project. It differs from save_user because
-        # it will happily overwrite an existing file.
-        def self.save_public_automatic(*args)
-            save_generated true, *args
-        end
-        
-        # call-seq:
-        #   save_user path1, path2, ..., file_name, data
-        #
-        # Save the provided data in the path1/path2/file_name file of the
-        # user-written part of the project, if the said file does
-        # not exist yet
-        def self.save_user(*args)
-            result = save_generated false, *args
-
-            # Save the template in path1/path2/.../orogen/file_name
-            args = args.dup
-            args.unshift "templates"
-            save_generated true, *args
-            result
-        end
-
-        # Removes from the given path all files that have not been generated
-        def self.cleanup_dir(*path)
-            dir_path = File.expand_path(File.join(*path))
-
-            Find.find(dir_path) do |file|
-                if File.directory?(file) && File.directory?(File.join(file, "CMakeFiles"))
-                    # This looks like a build directory. Ignore
-                    Find.prune
-                
-                elsif File.file?(file) && !File.symlink?(file) && !generated_files.include?(file)
-                    info "   removing #{file}"
-                    FileUtils.rm_f file
+                File.open(file_path, 'w') do |io|
+                    io.write data
                 end
+                file_path
             end
-        end
 
-        def self.really_clean
-            # List all files in templates and compare them w.r.t.  the ones in
-            # the user-side of the project. Remove those that are identical
-            base_dir     = Pathname.new('.')
-            template_dir = Pathname.new('templates')
-            template_dir.find do |path|
-                next unless path.file?
-                template_data = File.read(path.to_s)
-                relative = path.relative_path_from(template_dir)
+            # call-seq:
+            #   save_automatic path1, path2, ..., file_name, data
+            #
+            # Save the provided data in the path1/path2/.../file_name file of the
+            # automatically-generated part of the project (i.e. under .orogen)
+            def self.save_automatic(*args)
+                save_generated true, AUTOMATIC_AREA_NAME, *args
+            end
 
-                if relative.file?
-                    user_data = File.read(relative.to_s)
-                    if user_data == template_data
-                        logger.info "removing #{relative} as it is the same than in template"
-                        FileUtils.rm_f relative.to_s
+            # call-seq:
+            #   save_public_automatic path1, path2, ..., file_name, data
+            #
+            # Save the provided data in the path1/path2/file_name file of the
+            # user-written part of the project. It differs from save_user because
+            # it will happily overwrite an existing file.
+            def self.save_public_automatic(*args)
+                save_generated true, *args
+            end
+
+            # call-seq:
+            #   save_user path1, path2, ..., file_name, data
+            #
+            # Save the provided data in the path1/path2/file_name file of the
+            # user-written part of the project, if the said file does
+            # not exist yet
+            def self.save_user(*args)
+                result = save_generated false, *args
+
+                # Save the template in path1/path2/.../orogen/file_name
+                args = args.dup
+                args.unshift "templates"
+                save_generated true, *args
+                result
+            end
+
+            # Removes from the given path all files that have not been generated
+            def self.cleanup_dir(*path)
+                dir_path = File.expand_path(File.join(*path))
+
+                Find.find(dir_path) do |file|
+                    cmakefiles_path = File.join(file, 'CMakeFiles')
+                    is_generated = generated_files.include?(file)
+                    if File.directory?(file) && File.directory?(cmakefiles_path)
+                        # This looks like a build directory. Ignore
+                        Find.prune
+
+                    elsif !is_generated && File.file?(file) && !File.symlink?(file)
+                        debug "   removing #{file}"
+                        FileUtils.rm_f file
                     end
                 end
             end
-            
-            # Call #clean afterwards, since #clean removes the templates/ directory
-            clean
-        end
 
-        def self.clean
-            FileUtils.rm_rf Generation::AUTOMATIC_AREA_NAME
-            FileUtils.rm_rf "build"
-            FileUtils.rm_rf "templates"
-        end
+            def self.really_clean
+                # List all files in templates and compare them w.r.t.  the ones in
+                # the user-side of the project. Remove those that are identical
+                template_dir = Pathname.new('templates')
+                template_dir.find do |path|
+                    next unless path.file?
+
+                    template_data = File.read(path.to_s)
+                    relative = path.relative_path_from(template_dir)
+
+                    if relative.file?
+                        user_data = File.read(relative.to_s)
+                        if user_data == template_data
+                            logger.info "removing #{relative} as it is the same "\
+                                        'than in template'
+                            FileUtils.rm_f relative.to_s
+                        end
+                    end
+                end
+
+                # Call #clean afterwards, since #clean removes the templates/ directory
+                clean
+            end
+
+            def self.clean
+                FileUtils.rm_rf Generation::AUTOMATIC_AREA_NAME
+                FileUtils.rm_rf 'build'
+                FileUtils.rm_rf 'templates'
+            end
         end
     end
 end

--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -355,7 +355,7 @@ module OroGen
                 end
                 pointed_to = File.readlink(target)
                 if pointed_to == target
-                    return 
+                    return
                 else
                     FileUtils.rm_f target
                 end
@@ -569,7 +569,7 @@ module OroGen
             def standalone?
                 !project
             end
-            
+
             # Register a new plugin class. The plugin name is taken from
             # klass.name
             def self.register_plugin(klass)
@@ -936,7 +936,7 @@ module OroGen
 
             # Ask to support a smart-pointer implementation on the given type.
             # For instance, after the call
-            #  
+            #
             #   smart_ptr "boost::smart_ptr", "int"
             #
             # You will be able to use the following type in your task
@@ -1035,7 +1035,7 @@ module OroGen
             # Orogen has a specific support for data held by smart pointers. See #smart_ptr.
             #
             # The following options are available:
-            # 
+            #
             # +:includes+ is an optional set of headers needed to define
             # +base_type+. For instance:
             #
@@ -1111,7 +1111,7 @@ module OroGen
                     opaque_type.metadata.add('orogen_include', "#{self.name}:#{inc}")
                 end
                 orogen_def  = OpaqueDefinition.new(opaque_type,
-                                                 intermediate_type, options, convert_code_generator) 
+                                                 intermediate_type, options, convert_code_generator)
                 orogen_def.caller = caller
                 @opaques << orogen_def
                 @opaques = opaques.
@@ -1161,7 +1161,7 @@ module OroGen
             # * <tt>std::vector< <i>type</i> ></tt>. You *have* to specify
             #   <tt>std::vector</tt> (and not simply +vector+, as the <tt>using
             #   namespace</tt> directive is not supported by orogen.
-            # 
+            #
             # Moreover, the orogen tool defines the <tt>__orogen</tt>
             # preprocessor symbol when it loads the file. It is therefore
             # possible to define constructors, destructors, operators and (more
@@ -1169,7 +1169,7 @@ module OroGen
             #   #ifndef __orogen
             #   ... C++ code not supported by orogen ...
             #   #endif
-            # 
+            #
             # <b>The use of virtual methods and inheritance is completely
             # forbidden</b>. The types need to remain "value types" without
             # inheritance. For those who want to know, this is needed so that
@@ -1178,7 +1178,7 @@ module OroGen
             #
             # @raises LoadError if the file does not exist
             def load(file, add = true, user_options = Hash.new)
-                if !user_options.respond_to?(:to_hash) 
+                if !user_options.respond_to?(:to_hash)
                     raise ArgumentError, "expected an option has as third argument, got #{user_options.inspect}"
                 end
 
@@ -1355,7 +1355,7 @@ module OroGen
                     end
                 end
             end
-            
+
             def compute_orogen_include_on_type(type, file_to_include)
                 if includes = orogen_include_of_type(type, file_to_include)
                     type.metadata.set('orogen_include', *includes)
@@ -1509,20 +1509,25 @@ module OroGen
                 preprocessed, include_mappings = resolve_toplevel_include_mapping(loads, preprocess_options)
 
                 include_path = include_dirs.map { |d| Pathname.new(d) }
-                pending_loads_to_relative = loads.inject(Hash.new) do |map, path|
-                    map[path] = resolve_full_include_path_to_relative(path, include_path)
-                    map
-                end
+                pending_loads_to_relative =
+                    loads.each_with_object(Hash.new) do |path, map|
+                        map[path] = resolve_full_include_path_to_relative(path, include_path)
+                    end
 
                 include_mappings.each do |file, lines|
                     lines.map! { |inc| pending_loads_to_relative[inc] }
                 end
 
-                Tempfile.open(["orogen-pending-loads_",".hpp"]) do |io|
+                logger = OroGen::Gen::RTT_CPP.logger
+                Tempfile.open(['orogen-pending-loads_', '.hpp']) do |io|
                     io.write preprocessed
                     io.flush
 
                     begin
+                        logger.info "typekit: loading #{loads.size} headers"
+                        loads.each do |path|
+                            logger.info "typekit:  #{path}"
+                        end
                         file_registry.import(io.path, 'c', options)
                         filter_unsupported_types(file_registry)
                         resolve_registry_includes(file_registry, include_mappings)
@@ -1531,8 +1536,11 @@ module OroGen
                         if project
                             project.registry.merge(file_registry)
                         end
-                    rescue Exception => e
-                        raise ArgumentError, "cannot load one of the header files #{loads.join(", ")}: #{e.message}", e.backtrace
+                    rescue RuntimeError => e
+                        raise ArgumentError,
+                              'cannot load one of the header files '\
+                              "#{loads.join(", ")}: #{e.message}",
+                              e.backtrace
                     end
                 end
 
@@ -1640,7 +1648,7 @@ module OroGen
                 types.each do |type|
                     loop do
                         imported_typekits.each do |tk|
-                            if type < Typelib::ArrayType 
+                            if type < Typelib::ArrayType
                                 if tk.defines_array_of?(type.deference)
                                     result << tk
                                 end

--- a/lib/orogen/marshallers/corba.rb
+++ b/lib/orogen/marshallers/corba.rb
@@ -280,7 +280,7 @@ module OroGen
             result << "#{indent}corba.length(value.size());\n"
             # Special case for array of bytes, we can do a simple memcpy
             # (maybe extend that later)
-            if collection_name == "/std/vector" && 
+            if collection_name == "/std/vector" &&
                 element_type < NumericType &&
                 element_type.integer? &&
                 element_type.size == 1
@@ -319,7 +319,7 @@ module OroGen
                 result << "#{indent}size_t const size_#{element_idx} = corba.length();\n"
                 result << "#{indent}value.resize(size_#{element_idx});\n"
 
-                if collection_name == "/std/vector" && 
+                if collection_name == "/std/vector" &&
                     element_type < NumericType
 
                     result << "if (!value.empty()) #{indent}memcpy(&value[0], &corba[0], size_#{element_idx});"
@@ -411,7 +411,7 @@ EOT
             element_type = registry.build(element_type)
 
             # Special case for array of numerics, we can do a simple memcpy
-            if  element_type < NumericType 
+            if  element_type < NumericType
                 result << "#{indent}const int array_size = length * sizeof(#{element_type.cxx_name});\n"
                 result << "#{indent}memcpy(corba, value, array_size);"
             else
@@ -425,7 +425,7 @@ EOT
             element_type = registry.build(element_type)
 
             # Special case for array of numerics, we can do a simple memcpy
-            if  element_type < NumericType 
+            if  element_type < NumericType
                 result << "#{indent}const int array_size = length * sizeof(#{element_type.cxx_name});\n"
                 result << "#{indent}memcpy(value, corba, array_size);"
             else

--- a/lib/orogen/templates/typekit/corba/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/corba/CMakeLists.txt
@@ -24,7 +24,9 @@ endif(CORBA_IMPLEMENTATION STREQUAL "OMNIORB")
 
 add_custom_command(OUTPUT ${CORBA_FILES}
     COMMAND ${OrocosCORBA_IDL} -Wbkeep_inc_path
-        <%= typekit.used_typekits.find_all { |tk| !tk.virtual? }.map { |tk| "-I" + File.join(tk.pkg.prefix, "include", "orocos") }.join(" ") %>
+        <%= corba_plugin.corba_idl_requires.to_a.sort
+                        .map { |name| typekit.project.orogen_typekit_package(name).prefix }
+                        .map { |prefix| "-I" + File.join(prefix, "include", "orocos") }.join(" ") %>
         ${CMAKE_CURRENT_SOURCE_DIR}/<%= typekit.name %>Types.idl
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/<%= typekit.name %>Types.idl)
 

--- a/lib/orogen/templates/typekit/corba/transport-corba.pc
+++ b/lib/orogen/templates/typekit/corba/transport-corba.pc
@@ -10,6 +10,7 @@ project_name=<%= typekit.name %>
 deffile=${prefix}/share/orogen/<%= File.basename(typekit.project.deffile) %>
 <% end %>
 type_registry=${prefix}/share/orogen/<%= typekit.name %>.tlb
+corba_idl_requires=<%= corba_plugin.corba_idl_requires.to_a.sort.join(",") %>
 
 Name: <%= typekit.name %>CorbaTransport
 Version: <%= typekit.version %>


### PR DESCRIPTION
Build tests added by:
- [ ] https://github.com/rock-core/rock.build-tests-package_set/pull/4

We generate one IDL file per typekit, which means that include paths should be transitive. The current code was using `#used_typekits`, which only computes the typekits that the types exported by the typekit need.

Let's assume typekit [X](https://github.com/rock-core/build_tests-orogen-typekit_idl_cross_dependency_regression_1/blob/master/typekit_idl_cross_dependency_regression_1Types.hpp) defines type `BaseUsingStruct` and `StdUsingStruct`. `BaseUsingStruct` reuses a type already defined by typekit `base`. `StdUsingStruct` reuses a type already defined by typekit `std`.

Now, we have typekit [Y](https://github.com/rock-core/build_tests-orogen-typekit_idl_cross_dependency_regression_2/blob/master/typekit_idl_cross_dependency_regression_2Types.hpp) which defines `EndStruct`. `EndStruct` reuses `StdUsingStruct`, but nothing in `Y` uses something from `base`. This was causing the CMake code to only add the include paths for `std` and not `base`, and generation failed.

This commit fixes it by essentially adding the `-I` options recursively.

