### PR TITLE
gen: implement generic global initializer support for deployments

### DIFF
--- a/lib/orogen/gen/project.rb
+++ b/lib/orogen/gen/project.rb
@@ -305,6 +305,27 @@ module OroGen
                 project.used_typekits.find { |tk| tk.name == typekit_name }
             end
 
+            # @api private
+            #
+            # Enumerate the global initializers needed by the tasks in this project
+            #
+            # This is used solely during code generation as global initializers can
+            # register code to be generated in the tasks's CMake
+            #
+            # @yieldparam [Deployment::GlobalInitializer]
+            def each_needed_global_cpp_initializer
+                return enum_for(__method__) unless block_given?
+
+                unique = Set.new
+                self_tasks.each do |task|
+                    task.each_needed_global_initializer do |key|
+                        if unique.add?(key)
+                            yield(Deployment.resolve_global_initializer(key))
+                        end
+                    end
+                end
+            end
+
             # Returns all subdirectores that task-extens want to add
             # This is used within the CMake-list generation to add
             # custom targets to the build process

--- a/lib/orogen/spec.rb
+++ b/lib/orogen/spec.rb
@@ -20,6 +20,8 @@ require 'orogen/spec/dynamic_ports'
 require 'orogen/spec/task_context'
 require 'orogen/spec/deployment'
 
+OroGen::Spec::Deployment.register_global_initializer(:qt)
+
 require 'orogen/spec/typekit'
 require 'orogen/spec/project'
 

--- a/lib/orogen/templates/config/Deployment.cmake
+++ b/lib/orogen/templates/config/Deployment.cmake
@@ -35,15 +35,9 @@ endif()
 
 target_link_libraries(<%= deployer.name %> ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${Boost_SYSTEM_LIBRARIES})
 
-<% if uses_qt? %>
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
-include_directories(${QT_INCLUDE_DIR})
-link_directories(${QT_LIBRARY_DIR})
-target_link_libraries(<%= deployer.name %> ${QT_LIBRARIES})
-set(CMAKE_AUTOMOC true)
+<% deployer.each_needed_global_cpp_initializer do |init| %>
+<%= ERB.new(init.deployment_cmake).result(binding) %>
 <% end %>
-
 
 list(APPEND CMAKE_PREFIX_PATH ${OrocosRTT_PREFIX})
 find_package(RTTPlugin COMPONENTS rtt-typekit <%= deployer.rtt_transports.map { |transport_name| "rtt-transport-#{transport_name}" }.join(" ") %>)

--- a/lib/orogen/templates/tasks/CMakeLists.txt
+++ b/lib/orogen/templates/tasks/CMakeLists.txt
@@ -1,21 +1,16 @@
 # Generated from orogen/lib/orogen/templates/tasks/CMakeLists.txt
 
 include(<%= project.name %>TaskLib)
-ADD_LIBRARY(${<%= project.name.upcase %>_TASKLIB_NAME} SHARED 
+ADD_LIBRARY(${<%= project.name.upcase %>_TASKLIB_NAME} SHARED
     ${<%= project.name.upcase %>_TASKLIB_SOURCES})
 <% if project.typekit %>
 add_dependencies(${<%= project.name.upcase %>_TASKLIB_NAME}
     regen-typekit)
 <% end %>
 
-<% if self_tasks.any?{|t| t.uses_qt?} %>
-find_package(Qt4 REQUIRED)
-include(${QT_USE_FILE})
-include_directories(${QT_INCLUDE_DIR})
-link_directories(${QT_LIBRARY_DIR})
-set(CMAKE_AUTOMOC true)
+<% project.each_needed_global_cpp_initializer do |init| %>
+<%= ERB.new(init.tasks_cmake).result(binding) %>
 <% end %>
-
 
 TARGET_LINK_LIBRARIES(${<%= project.name.upcase %>_TASKLIB_NAME}
     ${OrocosRTT_LIBRARIES}


### PR DESCRIPTION
This may be used for any library that need a one-time initialization
in main. So far, orogen had only support for Qt. I needed this for
instance for GStreamer.

This is tested against Qt4 and GStreamer.