### PR TITLE
fix return value of method_name in case typename contains a *

### DIFF
--- a/lib/orogen/gen/typekit.rb
+++ b/lib/orogen/gen/typekit.rb
@@ -7,6 +7,16 @@ require 'utilrb/kernel/options'
 
 module Typelib
     class Type
+        MARKER_TO_METHOD_STRING = {
+            '*' => "_P_",
+            "[" => "_BROPEN_",
+            "]" => "_BRCLOSE_",
+            "," => "_COMMA_",
+            "<" => "_LT_",
+            ">" => "_GT_",
+            " " => "_WS_"
+        }
+
         def self.normalize_typename(name)
             "/" + Typelib.split_typename(name).map do |part|
                 normalize_typename_part(part)
@@ -98,7 +108,7 @@ module Typelib
             base = if fullname then full_name('_', true)
                    else basename('_')
                    end
-            base.gsub(/[<>\[\], ]/, '_')
+            base.gsub(/[<>\[\]\*, ]/) { |s| MARKER_TO_METHOD_STRING[s] }
         end
 
         def self.contains_int64?

--- a/test/gen/test_typekit.rb
+++ b/test/gen/test_typekit.rb
@@ -259,5 +259,29 @@ describe OroGen::Gen::RTT_CPP::Typekit do
             assert !reg.include?("/VectorTest")
             assert !reg.include?("/ArrayTest")
         end
+        it "properly canonizes method name" do
+            typenames = ["/std/vector<double*>",
+                         "/int64_t[100]",
+                         "/std/pair<int,double>"
+            ]
+            expected =  ["/std/vector_LT_double_P__GT_",
+                         "/int64_t_BROPEN_100_BRCLOSE_",
+                         "/std/pair_LT_int_COMMA_double_GT_"
+            ]
+
+            mocktype = flexmock(Typelib::Type)
+            flexmock(mocktype).should_receive(:full_name).and_return(*typenames)
+            flexmock(mocktype).should_receive(:name).and_return(*typenames)
+
+            typenames.each_with_index do |typename, index|
+                method_name = mocktype.method_name()
+                expected_method_name = expected[index]
+
+                assert method_name == expected_method_name,
+                    "Canonized method name for '#{typename}':
+                        '#{method_name}', expected was
+                        '#{expected_method_name}'"
+            end
+        end
     end
 end


### PR DESCRIPTION
This happens if for example Vector<Foo *> is given as opaque.

Extracted from #89 with added tests