### PR TITLE
fix the Qt global initializer

### DIFF
--- a/lib/orogen/gen.rb
+++ b/lib/orogen/gen.rb
@@ -50,11 +50,17 @@ OroGen::Gen::RTT_CPP::Deployment.register_global_initializer(
         static char const* QT_ARGV[] = { "orogen", nullptr };
         #include <pthread.h>
         #include <QApplication>
+
         void* qt_thread_main(void*)
         {
             QApplication *qapp = new QApplication(QT_ARGC, const_cast<char**>(QT_ARGV));
             qapp->setQuitOnLastWindowClosed(false);
-            reinterpret_cast<QCoreApplication*>(qapp)->exec();
+            // NOTE: we do NOT need to explicitely synchronize with the QApplication
+            // startup. The only safe way to interact with parts of Qt that require
+            // an event loop is through postEvent, which is safe to use even before
+            // the QApplication gets created
+
+            qapp->exec();
             return NULL;
         }
     QT_GLOBAL_SCOPE

--- a/lib/orogen/templates/main.cpp
+++ b/lib/orogen/templates/main.cpp
@@ -266,6 +266,10 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_RT, RTT::os::LowestPriority);
 RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
 <% end %>
 
+<% deployer.each_needed_global_cpp_initializer do |init| %>
+    <%= ERB.new(init.init).result(binding) %>
+<% end %>
+
 //First Create all Tasks to be able to set some (slave-) activities later on in the second loop
 <% task_activities.each do |task| %>
     task_name = "<%= task.name %>";
@@ -427,15 +431,12 @@ RTT::internal::GlobalEngine::Instance(ORO_SCHED_OTHER, RTT::os::LowestPriority);
         std::cerr << "failed to install SIGINT handler" << std::endl;
         return 1;
     }
+
     <% if has_realtime %>
     RTT::corba::TaskContextServer::ThreadOrb(ORO_SCHED_RT, RTT::os::LowestPriority, 0);
     <% else %>
     RTT::corba::TaskContextServer::ThreadOrb(ORO_SCHED_OTHER, RTT::os::LowestPriority, 0);
     <% end %>
-
-<% deployer.each_needed_global_cpp_initializer do |init| %>
-    <%= ERB.new(init.init).result(binding) %>
-<% end %>
 
     exiting = false;
     oro_thread(NULL);


### PR DESCRIPTION
The current implementation was just ... wrong. It probably was crashing things as soon as components were reconfigured (and sometimes at startup as well).

Tested through gui/orogen/qt_base (https://github.com/rock-core/rock.build-tests-buildconf/pull/9)