### PR TITLE
gen: allow to set the cmake keyword to target_link_libraries

### DIFF
--- a/lib/orogen/gen/base.rb
+++ b/lib/orogen/gen/base.rb
@@ -99,12 +99,18 @@ module OroGen
                 cmake_txt
             end
 
-            def self.cmake_pkgconfig_link(context, target, depspec)
-                depspec.inject([]) do |result, s|
+            def self.each_pkgconfig_link_dependency(context, depspec)
+                return enum_for(:each_pkgconfig_link_dependency, context, depspec) unless block_given?
+                depspec.each do |s|
                     if s.in_context?(context, "link")
-                        result << "target_link_libraries(#{target} ${#{s.var_name}_LIBRARIES})"
+                        yield "${#{s.var_name}_LIBRARIES}"
                     end
-                    result
+                end
+            end
+
+            def self.cmake_pkgconfig_link(context, target, depspec)
+                each_pkgconfig_link_dependency(context, depspec).map do |dep|
+                    "target_link_libraries(#{target} #{dep})"
                 end.join("\n") + "\n"
             end
 


### PR DESCRIPTION
[CMake Policy 0023](https://cmake.org/cmake/help/latest/policy/CMP0023.html) states that:
"Plain and keyword target_link_libraries() signatures cannot be mixed."

Therefore this change permits the keyword use when needed through context.