### PR TITLE
manifest.xml: switch metaruby to tag type <rosdep>

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -16,7 +16,7 @@
     <depend package="typelib" />
     <depend package="rtt_typelib" />
     <depend package="utilrb" />
-    <depend package="metaruby" />
+    <rosdep name="metaruby" />
     <rosdep name="rake" />
     <rosdep name="ruby" />
 

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
     thus offering an easy and fast development process.
   </description>
   <author>Sylvain Joyeux/sylvain.joyeux@m4x.org</author>
-  <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
   <license>GPL v2 or later</license>
 
   <url>http://rock-robotics.org/documentation/orogen</url>


### PR DESCRIPTION
… such that it can be installed correctly by [rosdep](https://wiki.ros.org/rosdep):

**Without this patch**:
```sh
$ rosdep install -y --from-path . --ignore-src
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
orogen: Missing resource metaruby
ROS path [0]=/build/orocos_toolchain
```

**With this patch** (on Ubuntu 18.04):
```
$ rosdep install -y --from-path . --ignore-src
executing command [sudo -H gem install metaruby]
Fetching: rexml-3.2.4.gem (100%)
Successfully installed rexml-3.2.4
Fetching: kramdown-2.3.0.gem (100%)
Successfully installed kramdown-2.3.0
Fetching: utilrb-3.1.0.gem (100%)
Successfully installed utilrb-3.1.0
Fetching: metaruby-2.0.0.gem (100%)
Successfully installed metaruby-2.0.0
Parsing documentation for rexml-3.2.4
Installing ri documentation for rexml-3.2.4
Parsing documentation for kramdown-2.3.0
Installing ri documentation for kramdown-2.3.0
Parsing documentation for utilrb-3.1.0
Installing ri documentation for utilrb-3.1.0
Parsing documentation for metaruby-2.0.0
Installing ri documentation for metaruby-2.0.0
Done installing documentation for rexml, kramdown, utilrb, metaruby after 2 seconds
4 gems installed
#All required rosdeps installed successfully
```

This patch effectively reverts 8cb82a57d42942c8a6029e043389f84c2e737848.

**Background information:**
Unfortunately rosdep still prefers `manifest.xml` (aka dry) before `package.xml` (aka wet) if it exists. In `manifest.xml` packages listed with `<depend>` must be valid ROS packages with a `package.xml` or `manifest.xml` file. In contrast, `<rosdep>` dependencies are looked up in the [rosdep database](https://github.com/ros/rosdistro/tree/master/rosdep). rosdep also supports packages of type `gem` (cf. [rosdep2/platforms/gem.py](https://github.com/ros-infrastructure/rosdep/blob/8dbac9c706260927eaf21e2cdddb9b026e85386b/src/rosdep2/platforms/gem.py)) and `metaruby` is [available as a gem](https://rubygems.org/gems/metaruby). So with this patch and after key `metaruby` has been added to the [rosdep database of ruby packages](https://github.com/ros/rosdistro/blob/master/rosdep/ruby.yaml), it is possible to install all dependencies of an [orocos_toolchain](https://github.com/orocos-toolchain/orocos_toolchain) workspace with [rosdep](https://wiki.ros.org/rosdep) again for source builds.

For binary releases into ROS `orogen` cannot depend on gems, and `metaruby` must be provided as a ROS package, too. That is what we did in 2014 in repo [metaruby-release](https://github.com/orocos-gbp/metaruby-release) for the indigo release and what triggered the change in 8cb82a57d42942c8a6029e043389f84c2e737848. But at the moment there are no binary releases in ROS and for source builds using the gem for `metaruby` is more convenient. If there would be binary ROS releases again in the future, it is possible to delete or rename `manifest.xml` in the release repository, such that bloom and other tools only consider the dependencies in `package.xml`, where there is no distinction between ROS packages and other dependencies found via rosdep.

As far as I know for Autoproj it does not matter whether dependencies are listed using tag `<rosdep>` or `<depend>`, correct?

In https://github.com/orocos-toolchain/rtt/pull/321 it has been discussed to eventually drop `manifest.xml` completely and switch to `autoproj.xml` to get rid of the ROS/Autoproj compatibility issues.

In the second commit, https://github.com/orocos-toolchain/orogen/pull/140/commits/7a294614dc6e1034eb2aeadc434ce1ff25196307, I updated the maintainer email in package.xml. The domain `lists.mech.kuleuven.be` does not work anymore  since the department switched to a centralized list server infrastructure at https://ls.kuleuven.be a few years ago. orocos-dev@orocos.org currently forwards to orocosdev@ls.kuleuven.be.