### PR TITLE
gen: implement Typekit#remove_types

### DIFF
--- a/test/data/typekit/remove_types.h
+++ b/test/data/typekit/remove_types.h
@@ -1,0 +1,21 @@
+#ifndef OROGEN_TESTS_REMOVE_TYPES_H
+#define OROGEN_TESTS_REMOVE_TYPES_H
+
+#include <vector>
+
+struct Base {
+    int field;
+};
+
+struct Field {
+    int field;
+};
+
+struct Derived : Base {
+    std::vector<Field> field;
+};
+
+typedef Base BaseTypedef;
+typedef Derived DerivedTypedef;
+
+#endif

--- a/test/gen/test_typekit.rb
+++ b/test/gen/test_typekit.rb
@@ -287,4 +287,32 @@ describe OroGen::Gen::RTT_CPP::Typekit do
             end
         end
     end
+
+    describe "#remove_types" do
+        before do
+            @typekit = OroGen::Gen::RTT_CPP::Typekit.new
+            @typekit.base_dir = File.join(__dir__)
+            @typekit.load File.join(__dir__, "..", "data", "typekit", "remove_types.h")
+        end
+
+        it "removes a leaf type and its aliases" do
+            @typekit.remove_types "/Derived"
+            @typekit.perform_pending_loads
+            assert_raises(Typelib::NotFound) { @typekit.find_type "/Derived" }
+            assert_raises(Typelib::NotFound) { @typekit.find_type "/DerivedTypedef" }
+        end
+
+        it "keeps non-removed types and their aliases" do
+            @typekit.remove_types "/Derived"
+            @typekit.perform_pending_loads
+            assert @typekit.find_type "/Base"
+            assert @typekit.find_type "/BaseTypedef"
+        end
+
+        it "does not remove a type that is used by another" do
+            @typekit.remove_types "/std/vector</Field>"
+            @typekit.perform_pending_loads
+            assert @typekit.find_type "/std/vector</Field>"
+        end
+    end
 end


### PR DESCRIPTION
The current implementation of type_export_policy only deals
with type *exports*, i.e. the RTT side of things. All types
within the imported headers are still processed, saved in the
tlb files and conversion methods (to e.g. CORBA) are generated
for them. This is so as the RTT side is the one that is really
heavy in compilation time and binary size.

However, there are some cases where types may be incompatible
with the conversion. For instance, CORBA forbids any identifier
to match a keyword. It's easy to modify when one controls said
header, but if (1) we don't control the header and (2) the header
contains both the offending type and types that *are* needed, we
ended up in a broken situation.

This new method allows to explicitly remove the problematic type(s)
even if they were imported.