### PR TITLE
use setTaskState when available

### DIFF
--- a/lib/orogen/templates/tasks/TaskBase.cpp
+++ b/lib/orogen/templates/tasks/TaskBase.cpp
@@ -90,16 +90,22 @@ void <%= task.basename %>Base::error(States state)
     _state.write(state);
     TaskContext::error();
 }
+void <%= task.basename %>Base::error()
+{ return error(RUNTIME_ERROR); }
 void <%= task.basename %>Base::exception(States state)
 {
     _state.write(state);
     TaskContext::exception();
 }
+void <%= task.basename %>Base::exception()
+{ return exception(EXCEPTION); }
 void <%= task.basename %>Base::fatal(States state)
 {
     _state.write(state);
     TaskContext::fatal();
 }
+void <%= task.basename %>Base::fatal()
+{ return fatal(FATAL_ERROR); }
 <%= task.basename %>Base::States <%= task.basename %>Base::state() const
 {
     return static_cast<<%= task.basename %>Base::States>(_state.getLastWrittenValue());
@@ -157,12 +163,6 @@ bool <%= task.basename %>Base::cleanup()
     StateExporter exporter(*this, _state);
     return <%= superclass.name %>::cleanup();
 }
-void <%= task.basename %>Base::fatal()
-{ return fatal(FATAL_ERROR); }
-void <%= task.basename %>Base::error()
-{ return error(RUNTIME_ERROR); }
-void <%= task.basename %>Base::exception()
-{ return exception(EXCEPTION); }
 <% end %>
 
 <% task.base_hook_code.keys.sort.each do |hook_name| %>

--- a/lib/orogen/templates/tasks/TaskBase.cpp
+++ b/lib/orogen/templates/tasks/TaskBase.cpp
@@ -78,21 +78,12 @@ void <%= task.basename %>Base::setupComponentInterface()
 
 <% if task.extended_state_support? %>
 
-#ifdef RTT_HAS_STATE_CHANGE_HOOK
-void <%= task.basename %>Base::error()
-{ return <%= superclass.name %>::error(); }
-void <%= task.basename %>Base::exception()
-{ return <%= superclass.name %>::exception(); }
-void <%= task.basename %>Base::fatal()
-{ return <%= superclass.name %>::fatal(); }
-#else
 void <%= task.basename %>Base::error()
 { return error(RUNTIME_ERROR); }
 void <%= task.basename %>Base::exception()
 { return exception(EXCEPTION); }
 void <%= task.basename %>Base::fatal()
 { return fatal(FATAL_ERROR); }
-#endif
 
 void <%= task.basename %>Base::report(States state)
 {

--- a/lib/orogen/templates/tasks/TaskBase.hpp
+++ b/lib/orogen/templates/tasks/TaskBase.hpp
@@ -115,12 +115,13 @@ namespace <%= space %>{
         bool recover();
         bool stop();
         bool cleanup();
-        void error();
-        void fatal();
-        void exception();
         <% end %>
 
         <% if task.extended_state_support? %>
+        void error();
+        void fatal();
+        void exception();
+
         void report(States state);
         void state(States state);
         void error(States state);

--- a/lib/orogen/templates/tasks/TaskBase.hpp
+++ b/lib/orogen/templates/tasks/TaskBase.hpp
@@ -109,12 +109,16 @@ namespace <%= space %>{
         bool start();
 
         <% if task.extended_state_support? && !task.superclass.extended_state_support? %>
+#ifdef RTT_HAS_STATE_CHANGE_HOOK
+        void setTaskState(TaskState state);
+#else
         // Reimplement TaskCore base methods to export the states to the outside
         // world
         bool configure();
         bool recover();
         bool stop();
         bool cleanup();
+#endif
         <% end %>
 
         <% if task.extended_state_support? %>


### PR DESCRIPTION
setTaskState has been introduced in Rock's fork of RTT. This commit allows orogen to use it
when available, and fall back to the old system when not.

See https://github.com/rock-core/rtt/pull/5 which introduced the method.