### PR TITLE
Fix a bug. When orocos used  in xenomai platform

### DIFF
--- a/lib/orogen/templates/typekit/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/CMakeLists.txt
@@ -102,8 +102,8 @@ add_library(${libname} SHARED
 
 <%= Generation.cmake_pkgconfig_link_noncorba('${libname}', typekit_deps) %>
 target_link_libraries(${libname} ${OrocosRTT_LIBRARIES} ${TYPEKIT_ADDITIONAL_LIBRARIES} ${TOOLKIT_ADDITIONAL_LIBRARIES})
-set_target_properties(${libname} PROPERTIES LINK_INTERFACE_LIBRARIES ${OrocosRTT_LIBRARIES})
-set_target_properties(${libname} PROPERTIES INTERFACE_LINK_LIBRARIES ${OrocosRTT_LIBRARIES})
+set_target_properties(${libname} PROPERTIES LINK_INTERFACE_LIBRARIES "${OrocosRTT_LIBRARIES}")
+set_target_properties(${libname} PROPERTIES INTERFACE_LINK_LIBRARIES "${OrocosRTT_LIBRARIES}")
 if(WITH_RPATH AND APPLE)
   set_target_properties( ${libname} PROPERTIES
     INSTALL_NAME_DIR "@rpath")

--- a/lib/orogen/templates/typekit/corba/CMakeLists.txt
+++ b/lib/orogen/templates/typekit/corba/CMakeLists.txt
@@ -52,8 +52,8 @@ if(WITH_RPATH AND APPLE)
 endif()
 
 <%= Generation.cmake_pkgconfig_link('corba', '${libname_corba}', typekit_deps) %>
-set_target_properties(${libname_corba} PROPERTIES LINK_INTERFACE_LIBRARIES ${OrocosCORBA_LIBRARIES})
-set_target_properties(${libname_corba} PROPERTIES INTERFACE_LINK_LIBRARIES ${OrocosCORBA_LIBRARIES})
+set_target_properties(${libname_corba} PROPERTIES LINK_INTERFACE_LIBRARIES "${OrocosCORBA_LIBRARIES}")
+set_target_properties(${libname_corba} PROPERTIES INTERFACE_LINK_LIBRARIES "${OrocosCORBA_LIBRARIES}")
 
 SET(PKG_CONFIG_FILE_CORBA ${CMAKE_CURRENT_BINARY_DIR}/<%= typekit.name %>-transport-corba-${OROCOS_TARGET}.pc)
 CONFIGURE_FILE(<%= typekit.name %>-transport-corba.pc.in ${PKG_CONFIG_FILE_CORBA} @ONLY)


### PR DESCRIPTION
Fix a bug. When orocos used  in xenomai platform, the default variable OrocosRTT_LIBRARIES is "/usr/local/lib/liborocos-rtt-xenomai.so;/usr/xenomai/lib/libalchemy.so;/usr/xenomai/lib/libcopperplate.so;/usr/xenomai/lib/libcobalt.so;/usr/xenomai/lib/libmodechk.so;/usr/lib/x86_64-linux-gnu/libpthread.so;/usr/lib/x86_64-linux-gnu/librt.so;-Wl,--no-as-needed;-Wl,@/usr/xenomai/lib/modechk.wrappers;/usr/xenomai/lib/xenomai/bootstrap-pic.o",

there are commas in this variable, this will lead the error "set_target_properties called with incorrect number of arguments." when we use the cmake.